### PR TITLE
remove activeevent from storage when unset

### DIFF
--- a/lib/hooks/useActiveEvents.ts
+++ b/lib/hooks/useActiveEvents.ts
@@ -32,6 +32,9 @@ function useActiveEvent(): [EventFull | undefined, (event: EventFull | undefined
     if (store) {
       sessionStorage.setItem('activeEvent', store)
     }
+    else {
+      sessionStorage.removeItem('activeEvent')
+    }
   }, [activeEventId])
 
   const setActiveEvent = (event: EventFull | undefined) => {


### PR DESCRIPTION
sessionStorage for active event was only set if there was an ativeEvent (so not when undefined) this now removes the sessionStorage if the activeEvent is undefined (i think).

![Animation](https://github.com/OxfordRSE/gutenberg/assets/60351846/f4e4d0e5-c29c-48f0-9815-ce2f4fc3dd1c)

closes #42 