### PR TITLE
Replace the organisation of the top level of material (the themes) with cards instead of ELK

### DIFF
--- a/components/NavDiagram.tsx
+++ b/components/NavDiagram.tsx
@@ -43,6 +43,7 @@ const layoutOptions = {
   'elk.nodeSize.constraints': 'MINIMUM_SIZE',
   'elk.layered.spacing.nodeNodeBetweenLayers': '20',
   'elk.aspectRatio': '1.7',
+  'elk.zoomToFit': 'true',
 };
 
 const layoutOptionsTheme = { 
@@ -55,6 +56,7 @@ const layoutOptionsTheme = {
   'elk.nodeSize.constraints': 'MINIMUM_SIZE',
   'elk.layered.spacing.nodeNodeBetweenLayers': '20',
   'elk.aspectRatio': '1.7',
+  'elk.zoomToFit': 'true',
 };
 
 const padding = "[top=50.0,left=12.0,bottom=12.0,right=12.0]";
@@ -304,13 +306,6 @@ function generate_material_nodes(material: Material, graph: ElkNode) {
       },
     }
   ));
-  nodes = nodes.concat(...material.themes.map((theme, i) => {
-    if (graph.children?.[i]) {
-      return generate_theme_nodes(material, theme, graph.children?.[i]);
-    } else {
-      return [];
-    }
-  }));
   return nodes;
 }
 
@@ -384,7 +379,7 @@ const NavDiagram: React.FC<NavDiagramProps> = ({ material, theme, course }) => {
 
     }, [stringifyMaterial]);
   const fitViewOptions: FitViewOptions = {
-    padding: 0.2,
+    padding: 0.15,
   };
   if (!nodes) {
     return <div>Generating diagram...</div>
@@ -401,6 +396,8 @@ const NavDiagram: React.FC<NavDiagramProps> = ({ material, theme, course }) => {
         nodes={nodes} edges={edges}
         nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
+        minZoom={0.2}
+        maxZoom={2}
         fitView
         fitViewOptions={fitViewOptions}
       >

--- a/lib/material.ts
+++ b/lib/material.ts
@@ -44,6 +44,7 @@ export type Theme = {
   markdown: string,
   courses: Course[],
   type: string,
+  summary?: string,
 }
 
 export type Material = {
@@ -147,6 +148,8 @@ export async function getTheme(theme: string, no_markdown=false) : Promise<Theme
   const themeObject = fm(themeBuffer);
   // @ts-expect-error
   const name = themeObject.attributes.name as string
+  // @ts-expect-error
+  const summary = themeObject.attributes.summary as string
   const markdown = no_markdown ? '' : themeObject.body as string
   const id = theme;
   // @ts-expect-error
@@ -154,7 +157,7 @@ export async function getTheme(theme: string, no_markdown=false) : Promise<Theme
   const courses = await Promise.all(coursesId.map(course => getCourse(theme, course)));
   const type = 'Theme';
 
-  return { id, name, markdown, courses, type };
+  return { id, name, markdown, courses, type, summary };
 }
 
 export async function getCourse(theme: string, course: string, no_markdown=false) : Promise<Course> {

--- a/pages/material/index.tsx
+++ b/pages/material/index.tsx
@@ -9,6 +9,8 @@ import { EventFull as Event, EventFull } from 'lib/types';
 import useSWR, { Fetcher } from 'swr'
 import { basePath } from 'lib/basePath'
 import useActiveEvent from 'lib/hooks/useActiveEvents'
+import { Button, Card, theme } from 'flowbite-react'
+import { concat } from 'cypress/types/lodash'
 
 type HomeProps = {
   material: Material,
@@ -16,14 +18,32 @@ type HomeProps = {
 }
 
 const Home: NextPage<HomeProps> = ({ material, events }) => {
+  const themeCards = generateThemeCards(material)
   return (
     <Layout material={material}>
-      <Content markdown={material.markdown} />
-      <NavDiagram material={material}/>
+      <div className="items-stretch px-2 md:px-10 lg:px-10 xl:px-20 2xl:px-32 grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+        {themeCards}
+      </div>
     </Layout>
   )
 }
 
+function generateThemeCards(material: Material) {
+  const cards = material.themes.map((theme, index) => (
+    <Card key={index} href={`${basePath}/material/${theme.id}`} className="w-90%">
+      <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+        {theme.name}
+      </h5>
+      <p>
+        {theme.summary}
+      </p>
+    </Card>  
+  ));
+
+  return (
+    cards
+  );
+}
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const events = await prisma.event.findMany({

--- a/pages/material/index.tsx
+++ b/pages/material/index.tsx
@@ -30,7 +30,7 @@ const Home: NextPage<HomeProps> = ({ material, events }) => {
 
 function generateThemeCards(material: Material) {
   const cards = material.themes.map((theme, index) => (
-    <Card key={index} href={`${basePath}/material/${theme.id}`} className="w-90%">
+    <Card key={theme.id} href={`${basePath}/material/${theme.id}`} className="w-90%">
       <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
         {theme.name}
       </h5>


### PR DESCRIPTION
looks like this now:

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/6733075f-1a63-45a5-b9e3-0cb522066051)

Also changes some of the view params of the fitview look nicer.

This partially deals with #23 