### PR TITLE
Add edit source button for github.

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 MATERIAL_DIR=".material"
-NEXT_PUBLIC_GITHUB_MATERIAL_BASE_URL = "https://github.com/UNIVERSE-HPC/course-material/edit/main"
+NEXT_PUBLIC_GITHUB_MATERIAL_BASE_URL = "https://github.com/UNIVERSE-HPC/course-material/"
 NEXT_PUBLIC_BASEPATH=""
 NEXTAUTH_URL=http://localhost:3002/gutenberg/api/auth
 NEXTAUTH_SECRET="secret here"

--- a/.env
+++ b/.env
@@ -5,6 +5,7 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 MATERIAL_DIR=".material"
+NEXT_PUBLIC_GITHUB_MATERIAL_BASE_URL = "https://github.com/UNIVERSE-HPC/course-material/edit/main"
 NEXT_PUBLIC_BASEPATH=""
 NEXTAUTH_URL=http://localhost:3002/gutenberg/api/auth
 NEXTAUTH_SECRET="secret here"

--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 MATERIAL_DIR=".material"
-NEXT_PUBLIC_GITHUB_MATERIAL_BASE_URL = "https://github.com/UNIVERSE-HPC/course-material/"
+NEXT_PUBLIC_MATERIAL_URL="https://github.com/UNIVERSE-HPC/course-material/edit/main"
 NEXT_PUBLIC_BASEPATH=""
 NEXTAUTH_URL=http://localhost:3002/gutenberg/api/auth
 NEXTAUTH_SECRET="secret here"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 import React from 'react'
 import { BiLogoGithub } from 'react-icons/bi'
 import { HiAtSymbol, HiCalendar } from 'react-icons/hi'
-import { baseGithubUrl } from 'lib/baseGithubUrl'
+import { baseMaterialUrl } from 'lib/baseMaterialUrl'
 
 interface Props {
   material: Material,
@@ -58,7 +58,7 @@ const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent
           <li>
             <div className="flex items-center">
               <svg className="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
-              <Link href={`${basePath}/material`} className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white">
+              <Link href={`/material`} className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white">
                   Material
               </Link>
             </div>
@@ -95,7 +95,7 @@ const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent
       </ol>
       { theme && course && section &&
         <span className="gap-2 flex items-center w-[15%]">
-          <Link passHref={true} href={`${baseGithubUrl}/edit/main/${theme.id}/${course.id}/${section.id}.md`} className="inline-flex text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white" style={{alignItems: "center"}}>
+          <Link passHref={true} href={`${baseMaterialUrl}/${theme.id}/${course.id}/${section.id}.md`} className="inline-flex text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white" style={{alignItems: "center"}}>
             <BiLogoGithub style={{verticalAlign: "bottom"}}/>
             Edit Source
           </Link>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,4 +1,5 @@
 import { Avatar, Dropdown } from 'flowbite-react'
+import { basePath } from 'lib/basePath'
 import { Course, Material, Section, Theme } from 'lib/material'
 import { Event, EventFull } from 'lib/types'
 import { signIn, signOut, useSession } from 'next-auth/react'
@@ -52,6 +53,16 @@ const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent
               Home
           </Link>
         </li>
+        {theme && 
+          <li>
+            <div className="flex items-center">
+              <svg className="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
+              <Link href={`${basePath}/material`} className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white">
+                  Material
+              </Link>
+            </div>
+          </li>
+        } 
         {theme && 
           <li>
             <div className="flex items-center">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,7 +5,9 @@ import { Event, EventFull } from 'lib/types'
 import { signIn, signOut, useSession } from 'next-auth/react'
 import Link from 'next/link'
 import React from 'react'
+import { BiLogoGithub } from 'react-icons/bi'
 import { HiAtSymbol, HiCalendar } from 'react-icons/hi'
+import { baseGithubUrl } from 'lib/baseGithubUrl'
 
 interface Props {
   material: Material,
@@ -19,9 +21,8 @@ interface Props {
   showAttribution: boolean
 }
 
-const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent, setShowAttribution, setSidebarOpen, sidebarOpen, showAttribution }) => {
+const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent, setShowAttribution, setSidebarOpen, sidebarOpen, showAttribution}) => {
   const { data: session } = useSession()
-
   const openAttribution = () => {
     setShowAttribution(true)
   }
@@ -92,6 +93,14 @@ const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent
           </li>
         }
       </ol>
+      { theme && course && section &&
+        <span className="gap-2 flex items-center w-[15%]">
+          <Link passHref={true} href={`${baseGithubUrl}/${theme.id}/${course.id}/${section.id}.md`} className="inline-flex text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white" style={{alignItems: "center"}}>
+            <BiLogoGithub style={{verticalAlign: "bottom"}}/>
+            Edit Source
+          </Link>
+        </span>
+      }
       <div className="gap-2 relative flex items-center">
         <Dropdown
           label={

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -95,7 +95,7 @@ const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent
       </ol>
       { theme && course && section &&
         <span className="gap-2 flex items-center w-[15%]">
-          <Link passHref={true} href={`${baseGithubUrl}/${theme.id}/${course.id}/${section.id}.md`} className="inline-flex text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white" style={{alignItems: "center"}}>
+          <Link passHref={true} href={`${baseGithubUrl}/edit/main/${theme.id}/${course.id}/${section.id}.md`} className="inline-flex text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white" style={{alignItems: "center"}}>
             <BiLogoGithub style={{verticalAlign: "bottom"}}/>
             Edit Source
           </Link>

--- a/lib/baseGithubUrl.ts
+++ b/lib/baseGithubUrl.ts
@@ -1,0 +1,1 @@
+export const baseGithubUrl = process.env.NEXT_PUBLIC_GITHUB_MATERIAL_BASE_URL;

--- a/lib/baseGithubUrl.ts
+++ b/lib/baseGithubUrl.ts
@@ -1,1 +1,0 @@
-export const baseGithubUrl = process.env.NEXT_PUBLIC_GITHUB_MATERIAL_BASE_URL;

--- a/lib/baseMaterialUrl.ts
+++ b/lib/baseMaterialUrl.ts
@@ -1,0 +1,1 @@
+export const baseMaterialUrl = process.env.NEXT_PUBLIC_MATERIAL_URL;


### PR DESCRIPTION
This closes #20, linking on each section page to an editable github page of the material.

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/cf8aa779-d240-4c94-a31c-1e4d5841ccfb)


Also adds a link back to /material in the top bar, closes #48 

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/4ff21d5d-be44-42c7-b812-4b95884a5116)
