### PR TITLE
#55 sort events by date, change to locale date string

### DIFF
--- a/components/EventView.tsx
+++ b/components/EventView.tsx
@@ -53,7 +53,7 @@ const EventView: React.FC<EventsProps> = ({ material, event }) => {
         <Timeline.Point />
         <Timeline.Content>
           <Timeline.Time>
-            {new Date(group.start).toUTCString()}
+            {new Date(group.start).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}
           </Timeline.Time>
           <Timeline.Title>
             <a href={`${basePath}/event/${event.id}/${group.id}`}  className="font-bold text-gray-800 dark:text-gray-300 hover:underline">

--- a/components/EventsView.tsx
+++ b/components/EventsView.tsx
@@ -24,6 +24,17 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
   for (let i = 0; i < events.length; i++) {
     events[i].start = new Date(events[i].start)
   }
+  
+  // sort events by start date
+  events.sort((a, b) => {
+    if (a.start < b.start) {
+      return -1
+    }
+    if (a.start > b.start) {
+      return 1
+    }
+    return 0
+  })
 
   const handleCreateEvent = () => {
     postEvent().then((event) => mutate([...(currentEvents || []), event]))
@@ -37,7 +48,7 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
             <Timeline.Point />
             <Timeline.Content>
               <Timeline.Time>
-                <Link href={`/event/${event.id}`}>{event.start.toUTCString()}</Link>
+                <Link href={`/event/${event.id}`}>{event.start.toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}</Link>
               </Timeline.Time>
               <Timeline.Title>
                 <Link href={`/event/${event.id}`}>{event.name}</Link>

--- a/components/EventsView.tsx
+++ b/components/EventsView.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Material } from 'lib/material'
 import { EventFull, Event } from 'lib/types'
 import { Button, Timeline } from 'flowbite-react'
@@ -16,6 +16,12 @@ type EventsProps = {
 }
 
 const EventsView: React.FC<EventsProps> = ({ material, events }) => {
+  // don't show date/time until the page is loaded (due to rehydration issues)
+  const [showDateTime, setShowDateTime] = useState(false);
+  useEffect(() => {
+    setShowDateTime(true);
+  }, []);
+
   const { events: currentEvents, mutate } = useEvents();
   if (currentEvents) {
     events = currentEvents;
@@ -48,7 +54,7 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
             <Timeline.Point />
             <Timeline.Content>
               <Timeline.Time>
-                <Link href={`/event/${event.id}`}>{event.start.toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}</Link>
+                <Link href={`/event/${event.id}`}>{showDateTime && event.start.toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}</Link>
               </Timeline.Time>
               <Timeline.Title>
                 <Link href={`/event/${event.id}`}>{event.name}</Link>

--- a/components/content/Comment.tsx
+++ b/components/content/Comment.tsx
@@ -75,7 +75,7 @@ const CommentView = ({ comment, mutateComment, deleteComment}: Props) => {
                 {comment?.createdByEmail}
               </span>
               <span className="block text-sm">
-                {comment?.created ? new Date(comment?.created).toUTCString() : ""}
+                {comment?.created ? new Date(comment?.created).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'}) : ""}
               </span>
               </>
             )}>

--- a/components/content/Thread.tsx
+++ b/components/content/Thread.tsx
@@ -157,7 +157,7 @@ const Thread = ({ threadId, active, setActive, onDelete}: ThreadProps) => {
             {commentThread?.createdByEmail}
           </span>
           <span className="block text-sm">
-            {commentThread?.created ? new Date(commentThread?.created).toUTCString() : ""}
+            {commentThread?.created ? new Date(commentThread?.created).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'}) : ""}
           </span>
           </>
         )}>

--- a/pages/api/event/[eventId].ts
+++ b/pages/api/event/[eventId].ts
@@ -47,7 +47,7 @@ const eventHandler = async (
   if (req.method === 'GET') {
     const event = await prisma.event.findUnique({
       where: { id: parseInt(eventId) },
-      include: { EventGroup: { include: { EventItem: true } }, UserOnEvent: { include: { user: true } } },
+      include: { EventGroup: { include: { EventItem: true }, orderBy: { start: "asc" } }, UserOnEvent: { include: { user: true } } },
     });
 
 

--- a/pages/api/eventGroup/[eventGroupId].ts
+++ b/pages/api/eventGroup/[eventGroupId].ts
@@ -76,6 +76,13 @@ const eventHandler = async (
         res.status(401).json({ error: 'Unauthorized' });
         return; 
     }
+    
+    // make sure EventItem.order is a number
+    eventItemData.forEach((eventItem) => {
+        if (typeof eventItem.order === 'string') {
+          eventItem.order = parseInt(eventItem.order);
+        }
+    });
 
     const updatedEventGroup = await prisma.eventGroup.update({
         where: { id: parseInt(eventGroupId) },

--- a/pages/event/[eventId].tsx
+++ b/pages/event/[eventId].tsx
@@ -89,7 +89,7 @@ const Event: NextPage<EventProps> = ({ material, event }) => {
   const eventView = (
     <>
       <Title text={event.name} />
-      <SubTitle text={`${new Date(event.start).toUTCString()} - ${new Date(event.end).toUTCString()}`} />
+      <SubTitle text={`${new Date(event.start).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})} - ${new Date(event.end).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}`} />
       <Content markdown={eventData ? eventData.content : event.content} />
       { ((isInstructor || isAdmin) && eventData ) && (
           <>

--- a/pages/event/[eventId].tsx
+++ b/pages/event/[eventId].tsx
@@ -93,10 +93,10 @@ const Event: NextPage<EventProps> = ({ material, event }) => {
       <Content markdown={eventData ? eventData.content : event.content} />
       { ((isInstructor || isAdmin) && eventData ) && (
           <>
-          <Title text="Student Progress" />
-          <EventProblems event={eventData} material={material} /> 
           <Title text="Unresolved Threads" />
           <EventCommentThreads event={eventData} material={material} /> 
+          <Title text="Student Progress" />
+          <EventProblems event={eventData} material={material} /> 
           </>
       )}
     </>

--- a/pages/event/[eventId].tsx
+++ b/pages/event/[eventId].tsx
@@ -24,7 +24,7 @@ import useProfile from 'lib/hooks/useProfile'
 import { Event as EventWithUsers } from 'pages/api/event/[eventId]'
 import Stack from 'components/ui/Stack'
 import { putEvent } from 'lib/actions/putEvent'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Prisma } from '@prisma/client'
 import SelectField from 'components/forms/SelectField'
 import Checkbox from 'components/forms/Checkbox'
@@ -38,6 +38,12 @@ type EventProps = {
 
 
 const Event: NextPage<EventProps> = ({ material, event }) => {
+  // don't show date/time until the page is loaded (due to rehydration issues)
+  const [showDateTime, setShowDateTime] = useState(false);
+  useEffect(() => {
+    setShowDateTime(true);
+  }, []);
+
   const { event: eventData, error: eventError, isLoading: eventIsLoading, mutate: mutateEvent } = useEvent(event.id)
   if (eventData) {
     event = eventData
@@ -89,7 +95,7 @@ const Event: NextPage<EventProps> = ({ material, event }) => {
   const eventView = (
     <>
       <Title text={event.name} />
-      <SubTitle text={`${new Date(event.start).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})} - ${new Date(event.end).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}`} />
+      <SubTitle text={showDateTime ? `${new Date(event.start).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})} - ${new Date(event.end).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}` : ''} />
       <Content markdown={eventData ? eventData.content : event.content} />
       { ((isInstructor || isAdmin) && eventData ) && (
           <>

--- a/pages/event/[eventId]/[eventGroupId].tsx
+++ b/pages/event/[eventId]/[eventGroupId].tsx
@@ -110,7 +110,7 @@ const EventGroupPage: NextPage<EventGroupProps> = ({ material, event, eventGroup
       <Title text={event.name} />
       </a>
       <SubTitle text={eventGroup.name} />
-      <SubTitle text={`Time: ${new Date(eventGroup.start).toUTCString()} - ${new Date(eventGroup.end).toUTCString()}`} />
+      <SubTitle text={`Time: ${new Date(eventGroup.start).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})} - ${new Date(eventGroup.end).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}`} />
       <SubTitle text={`Location: ${eventGroup.location}`} />
       <Content markdown={eventGroup.content} />
       <SubTitle text="Material" />

--- a/pages/event/[eventId]/[eventGroupId].tsx
+++ b/pages/event/[eventId]/[eventGroupId].tsx
@@ -14,7 +14,7 @@ import useProfile from 'lib/hooks/useProfile'
 import { Button, Tabs } from 'flowbite-react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { EventGroup } from 'pages/api/eventGroup/[eventGroupId]'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { putEventGroup } from 'lib/actions/putEventGroup'
 import Stack from 'components/ui/Stack'
 import Textfield from 'components/forms/Textfield'
@@ -32,6 +32,11 @@ type EventGroupProps = {
 }
 
 const EventGroupPage: NextPage<EventGroupProps> = ({ material, event, eventGroupId }) => {
+  // don't show date/time until the page is loaded (due to rehydration issues)
+  const [showDateTime, setShowDateTime] = useState(false);
+  useEffect(() => {
+    setShowDateTime(true);
+  }, []);
   const { eventGroup, error: eventGroupError, isLoading: eventGroupIsLoading, mutate: mutateEventGroup } = useEventGroup(eventGroupId)
   const { userProfile, error: profileError, isLoading: profileLoading } = useProfile();
   const isAdmin = userProfile?.admin;
@@ -110,7 +115,7 @@ const EventGroupPage: NextPage<EventGroupProps> = ({ material, event, eventGroup
       <Title text={event.name} />
       </a>
       <SubTitle text={eventGroup.name} />
-      <SubTitle text={`Time: ${new Date(eventGroup.start).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})} - ${new Date(eventGroup.end).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}`} />
+      <SubTitle text={showDateTime ? `Time: ${new Date(eventGroup.start).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})} - ${new Date(eventGroup.end).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}` : ''} />
       <SubTitle text={`Location: ${eventGroup.location}`} />
       <Content markdown={eventGroup.content} />
       <SubTitle text="Material" />


### PR DESCRIPTION
Fixes #55
Fixes #51

Also moves unresolved threads to top of event page to make them more obvious
Also fixes eventGroup API in case a string is sent for order (converts to int before storing to dbase)
Also orders eventGroup list by start date in returned Events from api (sort of related to #55)