### PR TITLE
Change dockerfile copies to speed up installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM node:16-alpine AS builder
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY . .
+COPY package.json .
+COPY yarn.lock .
+COPY prisma ./prisma
 RUN yarn install --frozen-lockfile
+COPY . .
 
 # If using npm with a `package-lock.json` comment out above and use below instead
 # RUN npm ci


### PR DESCRIPTION
This is a freebie, splitting the copy lets docker cache yarn install if only source code and not package.json has changed.