### PR TITLE
Lower z index of select button; keep hidden behind sidebar

### DIFF
--- a/components/EventActions.tsx
+++ b/components/EventActions.tsx
@@ -63,22 +63,22 @@ const EventActions: React.FC<EventActionsProps> = ({ event }) => {
   return (
     <div className="flex flex-row gap-2">
     { isActiveEvent ? (
-        <Button color="gray" onClick={handleDeactivate(event)}>
+        <Button color="gray" onClick={handleDeactivate(event)} style={{zIndex: 1}}>
         Unselect 
         <HiArrowNarrowRight className="ml-2 h-3 w-3" />
         </Button>
     ): isMyEvent ? (
-        <Button color="gray" onClick={handleActivate(event)}>
+        <Button color="gray" onClick={handleActivate(event)} style={{zIndex: 1}}>
         Select 
         <HiArrowNarrowRight className="ml-2 h-3 w-3" />
         </Button>
     ): isRequested ? (
-        <Button color="gray" disabled>
+        <Button color="gray" style={{zIndex: 1}} disabled >
         Requested
         </Button>
     ): session && (
     <>
-        <Button color="gray" onClick={handleEnrol(event)}>
+        <Button color="gray" onClick={handleEnrol(event)} style={{zIndex: 1}}>
         Enroll 
         <HiArrowNarrowRight className="ml-2 h-3 w-3" />
         </Button>


### PR DESCRIPTION
I didn't actually think this would work but this does stop the select button from appearing briefly infront of the sidebar.

before:

![select_bug](https://github.com/OxfordRSE/gutenberg/assets/60351846/9c641548-9805-4b2a-b023-2f0d5397f191)


After:

![select_fix](https://github.com/OxfordRSE/gutenberg/assets/60351846/5e705445-182c-4108-9ada-8d650a07bd43)
