### PR TITLE
Resize avatars to be consistent

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -107,9 +107,9 @@ const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent
             </Tooltip>
           </Link>
       }
-      <Tooltip content="Search Material">
+      {/* <Tooltip content="Search Material">
         <HiSearchCircle onClick={openSearch} style={{verticalAlign: "bottom'"}} className="pointer-events-auto cursor-pointer w-10 h-10 text-gray-500 hover:text-gray-400"/>
-      </Tooltip>
+      </Tooltip> */}
 
         <Dropdown
           label={
@@ -117,16 +117,18 @@ const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent
             {session ? (
               <Avatar
                   img={session.user?.image ? session.user?.image : undefined}
+                  style={{width: 32, height: 32}}
+                  size="sm"
                   rounded={true}
                   data-cy={`avatar-${session.user?.email}`}
-                  size="sm"
                 />
               
             ) : (
               <Avatar
+                  style={{width: 32, height: 32}}
+                  size="sm"
                   rounded={true}
                   data-cy={`avatar-not-signed-in`}
-                  size="sm"
                 />
 
             )

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,7 +4,7 @@ import { Event, EventFull } from 'lib/types'
 import { signIn, signOut, useSession } from 'next-auth/react'
 import Link from 'next/link'
 import React from 'react'
-import { BiLogoGithub, BiSearchAlt2 } from 'react-icons/bi'
+import { RxGithubLogo } from 'react-icons/rx'
 import { HiAtSymbol, HiCalendar, HiSearchCircle } from 'react-icons/hi'
 import { baseMaterialUrl } from 'lib/baseMaterialUrl'
 import { searchQueryState } from 'components/SearchDialog'
@@ -103,21 +103,21 @@ const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent
       { theme && course && section &&
           <Link passHref={true} href={`${baseMaterialUrl}/edit/main/${theme.id}/${course.id}/${section.id}.md`} className="inline-flex text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
             <Tooltip content="Edit Source">
-              <BiLogoGithub className="m-0 pointer-events-auto cursor-pointer w-10 h-10 text-gray-500 hover:text-gray-400"/>
+              <RxGithubLogo className="m-0 pointer-events-auto cursor-pointer w-8 h-8 text-gray-500 hover:text-gray-400"/>
             </Tooltip>
           </Link>
       }
-      {/* <Tooltip content="Search Material">
+      <Tooltip content="Search Material">
         <HiSearchCircle onClick={openSearch} style={{verticalAlign: "bottom'"}} className="pointer-events-auto cursor-pointer w-10 h-10 text-gray-500 hover:text-gray-400"/>
-      </Tooltip> */}
+      </Tooltip>
 
         <Dropdown
           label={
-          <div className="inline-flex items-center text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
+          <div className="inline-flex items-center text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white w-10 h-10">
             {session ? (
               <Avatar
                   img={session.user?.image ? session.user?.image : undefined}
-                  style={{width: 32, height: 32}}
+                  className='w-8 h-8'
                   size="sm"
                   rounded={true}
                   data-cy={`avatar-${session.user?.email}`}
@@ -125,7 +125,7 @@ const Navbar: React.FC<Props> = ({ theme, course, section, material, activeEvent
               
             ) : (
               <Avatar
-                  style={{width: 32, height: 32}}
+                  className='w-8 h-8'
                   size="sm"
                   rounded={true}
                   data-cy={`avatar-not-signed-in`}


### PR DESCRIPTION
There is some interaction between the flowbite dropdown component and the flowbite avatar component that makes the whole thing get resized when space is adjusted. This was apparent when the search icon was there but, it was pre-existing:

E.g. see here on mobile:

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/c457760f-539e-4429-a826-07f75a679165)

This stops this by forcing w and h, it also makes the spacing and the sizes completely consistent across the icons.

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/4e4f1ef9-5d2a-41f0-87b3-37681ebc37ac)
