### PR TITLE
Only save comment thread when first comment is saved (avoid blank comments)

### DIFF
--- a/components/content/Comment.tsx
+++ b/components/content/Comment.tsx
@@ -52,14 +52,23 @@ const CommentView = ({ comment, mutateComment, deleteComment}: Props) => {
     });
   }
 
+  const [textareaValue, setTextareaValue] = useState('');
+  
+  const handleTextareaValueChange = (newValue: string) => {
+    // This function will be called whenever the Textarea component's value changes
+    setTextareaValue(newValue);
+  };
   return (
     <form>
     <div className="mx-1 p-1 border border-gray-200 rounded-lg bg-slate-100 dark:bg-slate-800 dark:border-gray-700 mb-4" data-cy={`Comment:${comment.id}:Main`}>
       { (editing && hasEditPermission) ? (
       <div data-cy={`Comment:${comment.id}:Editing`}>
-        <Textarea control={control} name="markdown" />
+        <Textarea control={control} 
+                  name="markdown" 
+                  value={textareaValue}
+                  onValueChange={handleTextareaValueChange}/>
         <Stack direction='row-reverse'>
-          <TinyButton onClick={handleSubmit(onSubmit)}><MdSave data-cy={`Comment:${comment.id}:Save`} /></TinyButton>
+          <TinyButton onClick={handleSubmit(onSubmit)} disabled={!textareaValue}><MdSave data-cy={`Comment:${comment.id}:Save`} /></TinyButton>
         </Stack>
       </div>
       ) : (

--- a/components/content/Comment.tsx
+++ b/components/content/Comment.tsx
@@ -11,17 +11,19 @@ import { useSession } from 'next-auth/react'
 import { putComment } from 'lib/actions/putComment'
 import Stack from 'components/ui/Stack'
 import { TinyButton } from './Thread'
-import { CommentThread } from '@prisma/client'
 import deleteCommentAction from 'lib/actions/deleteComment'
 import useUser from 'lib/hooks/useUser'
+
 
 interface Props {
   comment: Comment
   mutateComment: (comment: Comment) => void
   deleteComment: (comment: Comment) => void
+  saveComment?: (placeholder: Comment) => void
+  isPlaceholder?: boolean
 }
 
-const CommentView = ({ comment, mutateComment, deleteComment}: Props) => {
+const CommentView = ({ comment, mutateComment, deleteComment, isPlaceholder, saveComment}: Props) => {
   const { control, handleSubmit, reset } = useForm<Comment>();
   const { userProfile, isLoading, error } = useProfile()
   const [ editing, setEditing ] = useState(comment.markdown === '')
@@ -39,6 +41,12 @@ const CommentView = ({ comment, mutateComment, deleteComment}: Props) => {
       reset(comment)
       mutateComment(comment)
     });
+    setEditing(false)
+  }
+
+  const onSubmitPlaceholder = (data: Comment) => {
+    if (!saveComment) return
+    saveComment(data)
     setEditing(false)
   }
 
@@ -68,7 +76,12 @@ const CommentView = ({ comment, mutateComment, deleteComment}: Props) => {
                   value={textareaValue}
                   onValueChange={handleTextareaValueChange}/>
         <Stack direction='row-reverse'>
-          <TinyButton onClick={handleSubmit(onSubmit)} disabled={!textareaValue}><MdSave data-cy={`Comment:${comment.id}:Save`} /></TinyButton>
+          {!isPlaceholder && (
+            <TinyButton onClick={handleSubmit(onSubmit)} disabled={!textareaValue}><MdSave data-cy={`Comment:${comment.id}:Save`} /></TinyButton>
+          )}
+          {isPlaceholder && saveComment && (
+            <TinyButton onClick={handleSubmit(onSubmitPlaceholder)} disabled={!textareaValue}><MdSave data-cy={`Comment:${comment.id}:Save`} /></TinyButton>
+          )}
         </Stack>
       </div>
       ) : (
@@ -92,15 +105,24 @@ const CommentView = ({ comment, mutateComment, deleteComment}: Props) => {
             </Tooltip>
           </div>
         )}
-        <Markdown markdown={comment.markdown} />
+        {!isPlaceholder && (
+          <Markdown markdown={comment.markdown} />
+        )}
+        {isPlaceholder && (
+          <Markdown markdown='' />
+          )}
         { hasEditPermission && (
           <Stack direction='row-reverse'>
-          <Tooltip content="Edit comment">
-            <TinyButton onClick={onEdit} dataCy={`Comment:${comment.id}:Edit`}><MdEdit /></TinyButton> 
-          </Tooltip>
-          <Tooltip content="Delete comment">
-            <TinyButton onClick={onDelete} dataCy={`Comment:${comment.id}:Delete`}><MdDelete /></TinyButton> 
-          </Tooltip>
+          {!isPlaceholder &&  (
+            <>
+              <Tooltip content="Edit comment">
+                <TinyButton onClick={onEdit} dataCy={`Comment:${comment.id}:Edit`}><MdEdit /></TinyButton> 
+              </Tooltip>
+              <Tooltip content="Delete comment">
+                <TinyButton onClick={onDelete} dataCy={`Comment:${comment.id}:Delete`}><MdDelete /></TinyButton> 
+              </Tooltip>
+            </>
+          )}
           </Stack>
         )}
         </div>

--- a/components/forms/Textarea.tsx
+++ b/components/forms/Textarea.tsx
@@ -7,8 +7,8 @@ type Props<T extends FieldValues> = {
   name: FieldPath<T>;
   control: Control<T>;
   rules?: Object;
-  value: string; 
-  onValueChange: (newValue: string) => void;
+  value?: string; 
+  onValueChange?: (newValue: string) => void;
 };
 
 function Textarea<T extends FieldValues>({ label, name, control, rules, value, onValueChange}: Props<T>): React.ReactElement {  

--- a/components/forms/Textarea.tsx
+++ b/components/forms/Textarea.tsx
@@ -7,9 +7,11 @@ type Props<T extends FieldValues> = {
   name: FieldPath<T>;
   control: Control<T>;
   rules?: Object;
+  value: string; 
+  onValueChange: (newValue: string) => void;
 };
 
-function Textarea<T extends FieldValues>({ label, name, control, rules }: Props<T>): React.ReactElement {
+function Textarea<T extends FieldValues>({ label, name, control, rules, value, onValueChange}: Props<T>): React.ReactElement {  
   return (
     <div>
     <Controller
@@ -17,6 +19,10 @@ function Textarea<T extends FieldValues>({ label, name, control, rules }: Props<
       control={control}
       rules={rules}
       render={({ field: { onChange, onBlur, value }, fieldState: { error, isDirty, isTouched } }) => {
+        // Call the onValueChange callback whenever the value changes
+        if (onValueChange && typeof onValueChange === 'function') {
+          onValueChange(value);
+        }
         return (
           <>
           <div className="mb-1 block">

--- a/cypress/component/CommentThread.cy.tsx
+++ b/cypress/component/CommentThread.cy.tsx
@@ -95,10 +95,11 @@ context ('with non-owner student', () => {
     tenMinutesFromNow.setTime(now.getTime() + 10 * 60 * 1000);
     cy.mount(
         <Thread
-          threadId={threadId}
+          thread={threadId}
           active={true}
           setActive={setActiveSpy}
           onDelete={onDeleteSpy}
+          finaliseThread={() => {}}
         />
       , { session: { expires: tenMinutesFromNow, user: currentUser } }
     );
@@ -242,10 +243,11 @@ context('with owner student', () => {
     tenMinutesFromNow.setTime(now.getTime() + 10 * 60 * 1000);
     cy.mount(
         <Thread
-          threadId={threadId}
+          thread={threadId}
           active={true}
           setActive={setActiveSpy}
           onDelete={onDeleteSpy}
+          finaliseThread={() => {}}
         />
       , { session: { expires: tenMinutesFromNow, user: currentUser } }
     );
@@ -347,10 +349,11 @@ context('with non-owner instructor', () => {
     tenMinutesFromNow.setTime(now.getTime() + 10 * 60 * 1000);
     cy.mount(
         <Thread
-          threadId={threadId}
+          thread={threadId}
           active={true}
           setActive={setActiveSpy}
           onDelete={onDeleteSpy}
+          finaliseThread={() => {}}
         />
       , { session: { expires: tenMinutesFromNow, user: currentUser } }
     );

--- a/lib/hooks/useCommentThread.ts
+++ b/lib/hooks/useCommentThread.ts
@@ -5,8 +5,8 @@ import { Data, CommentThread } from "pages/api/commentThread"
 
 // GET /api/events
 const fetcher: Fetcher<Data, string> = url => fetch(url).then(r => r.json())
-const useCommentThread= (id: number): { commentThread: CommentThread | undefined, error: string, isLoading: boolean, mutate: (commentThread: CommentThread) => void } => {
-  const apiPath = `${basePath}/api/commentThread/${id}`
+const useCommentThread= (id: number | undefined): { commentThread: CommentThread | undefined, error: string, isLoading: boolean, mutate: (commentThread: CommentThread) => void } => {
+  const apiPath = typeof id === 'number' ? `${basePath}/api/commentThread/${id}` : undefined
   const { data, isLoading, error, mutate } = useSWR(apiPath, fetcher)
   const errorString = error ? error : data && 'error' in data ? data.error : undefined;
   const commentThread = data && 'commentThread' in data ? data.commentThread: undefined;

--- a/pages/api/commentThread.ts
+++ b/pages/api/commentThread.ts
@@ -84,8 +84,7 @@ const commentThreadHandler = async (
     res.status(200).json({ commentThreads });
 
   } else if (req.method === 'POST') {
-    const { eventId, textRef, textRefStart, textRefEnd, section } = req.body.commentThread;
-
+    const { eventId, textRef, textRefStart, textRefEnd, section, initialCommentText } = req.body.commentThread;
     if (!eventId) {
         res.status(400).json({ error: 'Bad request, no eventId' });
         return;
@@ -113,7 +112,7 @@ const commentThreadHandler = async (
             Comment: {
               create: {
                 createdByEmail: userEmail,
-                markdown: '',
+                markdown: initialCommentText,
                 index: 0,
               }
             },


### PR DESCRIPTION
Now, instead of commentthreads being created as soon as the compose comment button is pressed, they are instead only saved if the student presses save comment.

The UI for the comments in the mean time is rendered using a "placeholder" comment, this means the pages that render the comment threads and commentview need some conditional logic for rendering both comments from the database and placeholder comments.

closes #82 

![dont save empty](https://github.com/OxfordRSE/gutenberg/assets/60351846/cce5aaf5-05d1-4b08-807d-eae50354e957)
