### PR TITLE
Change the view for instructors to show all students

### DIFF
--- a/components/EventItemView.tsx
+++ b/components/EventItemView.tsx
@@ -3,6 +3,7 @@ import { Material } from 'lib/material'
 import { EventFull, Event, Problem } from 'lib/types'
 import { basePath } from 'lib/basePath'
 import { EventItem } from '@prisma/client';
+import { useSession } from 'next-auth/react'
 
 type EventItemProps = {
   material: Material,
@@ -10,8 +11,10 @@ type EventItemProps = {
   problems?: Problem[],
 }
 
+const EventItemView: React.FC<EventItemProps> = ({ material, item, problems }) => {
+  
+  const { data: session } = useSession()
 
-const EventView: React.FC<EventItemProps> = ({ material, item, problems }) => {
   const split = item.section.split('.')
   let url = ''
   let name = `Error: ${item.section}`
@@ -44,8 +47,9 @@ const EventView: React.FC<EventItemProps> = ({ material, item, problems }) => {
   }
   let isCompleted = false;
   let completedLabel = '';
+
   if (problems !== undefined && itemProblems.length > 0) {
-    const completedProblems = problems.filter((p) => p.section === item.section && itemProblems.includes(p.tag) && p.complete);
+    const completedProblems = problems.filter((p) => p.section === item.section && itemProblems.includes(p.tag) && p.complete  && p.userEmail === session?.user?.email);
     completedLabel = `[${completedProblems.length}/${itemProblems.length}]`;
     isCompleted = completedProblems.length === itemProblems.length;
   }
@@ -58,4 +62,4 @@ const EventView: React.FC<EventItemProps> = ({ material, item, problems }) => {
   )
 }
 
-export default EventView
+export default EventItemView

--- a/components/EventItemView.tsx
+++ b/components/EventItemView.tsx
@@ -4,6 +4,8 @@ import { EventFull, Event, Problem } from 'lib/types'
 import { basePath } from 'lib/basePath'
 import { EventItem } from '@prisma/client';
 import { useSession } from 'next-auth/react'
+import { useSession } from 'next-auth/react'
+import { uniq } from 'cypress/types/lodash';
 
 type EventItemProps = {
   material: Material,
@@ -20,6 +22,7 @@ const EventItemView: React.FC<EventItemProps> = ({ material, item, problems }) =
   let name = `Error: ${item.section}`
   let key = item.id
   let indent = 0
+
 
   let itemProblems: string[] = []
   if (split.length === 3) {
@@ -48,10 +51,24 @@ const EventItemView: React.FC<EventItemProps> = ({ material, item, problems }) =
   let isCompleted = false;
   let completedLabel = '';
 
+  const uniqueUsers = new Set();
+  let uniqueUsersCount = 0;
   if (problems !== undefined && itemProblems.length > 0) {
-    const completedProblems = problems.filter((p) => p.section === item.section && itemProblems.includes(p.tag) && p.complete  && p.userEmail === session?.user?.email);
-    completedLabel = `[${completedProblems.length}/${itemProblems.length}]`;
-    isCompleted = completedProblems.length === itemProblems.length;
+    problems.forEach((problem) => {
+      uniqueUsers.add(problem.userEmail);
+    });
+    uniqueUsersCount = uniqueUsers.size;
+    const completedProblems = problems.filter((p) => p.section === item.section && itemProblems.includes(p.tag) && p.complete);
+    if (uniqueUsersCount > 1) {
+      // if you are an instructor then you get a total count of problems completed / total problems available to all students
+      completedLabel = `[${completedProblems.length}/${itemProblems.length * uniqueUsersCount}]`
+      isCompleted = completedProblems.length === (itemProblems.length * uniqueUsersCount);
+    }
+    else {
+      // if you are a student then you get a count of problems completed / total problems available to just you
+      completedLabel = `[${completedProblems.length}/${itemProblems.length}]`
+      isCompleted = completedProblems.length === itemProblems.length;
+    }
   }
 
 

--- a/components/EventItemView.tsx
+++ b/components/EventItemView.tsx
@@ -4,8 +4,7 @@ import { EventFull, Event, Problem } from 'lib/types'
 import { basePath } from 'lib/basePath'
 import { EventItem } from '@prisma/client';
 import { useSession } from 'next-auth/react'
-import { useSession } from 'next-auth/react'
-import { uniq } from 'cypress/types/lodash';
+
 
 type EventItemProps = {
   material: Material,

--- a/components/EventItemView.tsx
+++ b/components/EventItemView.tsx
@@ -13,8 +13,6 @@ type EventItemProps = {
 }
 
 const EventItemView: React.FC<EventItemProps> = ({ material, item, problems }) => {
-  
-  const { data: session } = useSession()
 
   const split = item.section.split('.')
   let url = ''
@@ -56,18 +54,11 @@ const EventItemView: React.FC<EventItemProps> = ({ material, item, problems }) =
     problems.forEach((problem) => {
       uniqueUsers.add(problem.userEmail);
     });
-    uniqueUsersCount = uniqueUsers.size;
     const completedProblems = problems.filter((p) => p.section === item.section && itemProblems.includes(p.tag) && p.complete);
-    if (uniqueUsersCount > 1) {
-      // if you are an instructor then you get a total count of problems completed / total problems available to all students
-      completedLabel = `[${completedProblems.length}/${itemProblems.length * uniqueUsersCount}]`
-      isCompleted = completedProblems.length === (itemProblems.length * uniqueUsersCount);
-    }
-    else {
-      // if you are a student then you get a count of problems completed / total problems available to just you
-      completedLabel = `[${completedProblems.length}/${itemProblems.length}]`
-      isCompleted = completedProblems.length === itemProblems.length;
-    }
+    uniqueUsersCount = Math.max(1, uniqueUsers.size); // to deal with =0
+    // instructors see total completed by all students / total problems available to all students
+    completedLabel = `[${completedProblems.length}/${itemProblems.length * uniqueUsersCount}]` 
+    isCompleted = completedProblems.length === (itemProblems.length * uniqueUsersCount);
   }
 
 


### PR DESCRIPTION
closes #103 #78 

Both indicate the same issue, that for instructors the problem solved count doesn't display correctly. This is because instructors get all problems done by users of type "student" when they make a eventid/problem api call whereas students only get their own problems.

Instead of fixing this, I have changed the logic such that for instructors, the total displayed is [total solved problems by all students]/[number of problems in section * uniqueusers]

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/7ca4cefe-1a8e-4345-bc9a-702300879e7c)
![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/4d1ebaa1-df49-4435-99c2-0d5b08ada7f4)
