### PR TITLE
Add button to delete event on frontpage

### DIFF
--- a/components/EventsView.tsx
+++ b/components/EventsView.tsx
@@ -8,6 +8,9 @@ import useEvents from 'lib/hooks/useEvents'
 import useProfile from 'lib/hooks/useProfile'
 import useActiveEvent from 'lib/hooks/useActiveEvents';
 import { postEvent } from 'lib/actions/postEvent';
+import { MdDelete } from 'react-icons/md';
+import { useRecoilState } from 'recoil';
+import { deleteEventModalState, deleteEventIdState, DeleteEventModal } from 'components/deleteEventModal';
 
 
 type EventsProps = {
@@ -18,6 +21,9 @@ type EventsProps = {
 const EventsView: React.FC<EventsProps> = ({ material, events }) => {
   // don't show date/time until the page is loaded (due to rehydration issues)
   const [showDateTime, setShowDateTime] = useState(false);
+  const [showDeleteEventModal, setShowDeleteEventModal] = useRecoilState(deleteEventModalState);
+  const [deleteEventId, setDeleteEventId] = useRecoilState(deleteEventIdState);
+
   useEffect(() => {
     setShowDateTime(true);
   }, []);
@@ -27,6 +33,8 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
     events = currentEvents;
   }
   const { userProfile } = useProfile();
+  const isAdmin= userProfile?.admin;
+
   for (let i = 0; i < events.length; i++) {
     events[i].start = new Date(events[i].start)
   }
@@ -46,6 +54,11 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
     postEvent().then((event) => mutate([...(currentEvents || []), event]))
   }
 
+  const openDeleteEventModal = (eventId : number) => {
+    setShowDeleteEventModal(true);
+    setDeleteEventId(eventId);
+  }
+
   return (
     <Timeline>
       {events.map((event) => {
@@ -53,8 +66,10 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
           <Timeline.Item key={event.id}>
             <Timeline.Point />
             <Timeline.Content>
-              <Timeline.Time>
+              <Timeline.Time className='flex' style={{ justifyContent: 'space-between' }}>
                 <Link href={`/event/${event.id}`}>{showDateTime && event.start.toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}</Link>
+                { isAdmin && (<MdDelete className="ml-2 inline text-red-500 flex"  style={{cursor:'pointer'}}
+                              size={18} onClick={() => openDeleteEventModal(event.id)} />)}
               </Timeline.Time>
               <Timeline.Title>
                 <Link href={`/event/${event.id}`}>{event.name}</Link>

--- a/components/EventsView.tsx
+++ b/components/EventsView.tsx
@@ -66,9 +66,9 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
           <Timeline.Item key={event.id}>
             <Timeline.Point />
             <Timeline.Content>
-              <Timeline.Time className='flex' style={{ justifyContent: 'space-between' }}>
+              <Timeline.Time className='flex justify-between'>
                 <Link href={`/event/${event.id}`}>{showDateTime && event.start.toLocaleString([], { dateStyle: 'medium', timeStyle: 'short'})}</Link>
-                { isAdmin && (<MdDelete className="ml-2 inline text-red-500 flex"  style={{cursor:'pointer'}}
+                { isAdmin && (<MdDelete className="ml-2 inline text-red-500 flex cursor-pointer"
                               size={18} onClick={() => openDeleteEventModal(event.id)} />)}
               </Timeline.Time>
               <Timeline.Title>

--- a/components/Overlay.tsx
+++ b/components/Overlay.tsx
@@ -8,6 +8,7 @@ import AttributionDialog from './AttributionDialog'
 import Sidebar from './Sidebar'
 import { SearchDialog, searchQueryState } from 'components/SearchDialog'
 import { useRecoilState } from 'recoil'
+import { DeleteEventModal, deleteEventModalState } from 'components/deleteEventModal'
 
 interface Props {
   material: Material,
@@ -27,6 +28,7 @@ interface Props {
 const Overlay: NextPage<Props> = ({material, theme, course, section, activeEvent, showAttribution, setShowAttribution, sidebarOpen, setSidebarOpen, prevUrl, nextUrl }: Props) => {
   const [showSearch, setShowSearch] = useRecoilState(searchQueryState);
   const [showTopButtons, setShowTopButtons] = useState(false);
+  const [showDeleteEventModal, setShowDeleteEventModal] = useRecoilState(deleteEventModalState);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -44,6 +46,10 @@ const Overlay: NextPage<Props> = ({material, theme, course, section, activeEvent
   
   const closeSearch = () => {
     setShowSearch(false)
+  }
+
+  const closeDeleteEvent = () => {
+    setShowDeleteEventModal(false)
   }
 
   const handleClose = () => {
@@ -78,6 +84,7 @@ const Overlay: NextPage<Props> = ({material, theme, course, section, activeEvent
       )}
       <AttributionDialog citations={attribution} isOpen={showAttribution} onClose={closeAttribution} />
       <SearchDialog onClose={closeSearch}/>
+      <DeleteEventModal onClose={closeDeleteEvent}/>
       <Sidebar material={material} activeEvent={activeEvent} sidebarOpen={sidebarOpen} handleClose={handleClose} />
       </div>
     </div>

--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -35,7 +35,7 @@ export const SearchDialog: React.FC<SearchProps> = ({onClose}) => {
   return (
 
       <Modal
-        dismissible={false}
+        dismissible={true}
         show={isOpen}
         onClose={onClose}
         initialFocus={1}

--- a/components/deleteEventModal.tsx
+++ b/components/deleteEventModal.tsx
@@ -1,0 +1,133 @@
+
+import React from 'react'
+import { useState, useEffect } from 'react'
+import { Button, Modal } from 'flowbite-react'
+import Stack from './ui/Stack'
+import { atom, useRecoilState} from 'recoil'
+import useEvent from 'lib/hooks/useEvent'
+import { deleteEvent } from 'lib/actions/deleteEvent'
+import useEvents from 'lib/hooks/useEvents'
+import { Toast } from 'flowbite-react'
+import { HiCheckCircle, HiX } from 'react-icons/hi'
+
+
+
+interface DeleteEventProps {
+    onClose: () => void;
+  }
+
+export const deleteEventModalState = atom({
+    key: 'deleteEventModalState',
+    default: false,
+    });
+
+export const deleteEventIdState = atom<number>({
+    key: 'deleteEventIdState',
+    default: undefined,
+    });
+
+
+export const DeleteEventModal: React.FC<DeleteEventProps> = ({onClose}) => {
+    const [showDeleteEventModal, setShowDeleteEventModal] = useRecoilState(deleteEventModalState);
+    const [deleteEventId, setDeleteEventId] = useRecoilState(deleteEventIdState);
+    const { event }  = useEvent(deleteEventId);
+    const {events, mutate: mutateEvents} = useEvents();
+    const [success, setSuccess] = useState<string | null>(null)
+    const [failure, setFailure] = useState<string | null>(null)
+    const [buttonDisabled, setButtonDisabled] = useState<boolean>(true)
+    let buttonTimer: string = '3'
+
+    // disable the button for 2 seconds
+    const enableButton = () => {
+        setTimeout(() => {
+            setButtonDisabled(false)
+        }, 2000)
+    }
+
+    useEffect(() => {
+        if (showDeleteEventModal === true) {
+            enableButton()
+        }
+        else {
+            setButtonDisabled(true)
+        }
+      }, [showDeleteEventModal]);
+    
+
+
+    const handleDeleteEvent = () => {
+        if (event == undefined) { return }
+        deleteEvent(event).then((deletedEvent) => {
+            if (deletedEvent == undefined) { return }
+            if (events != undefined) {
+                if ('id' in deletedEvent) {
+                    // ts thinks id is not on deletedEvent so we ignore
+                    // @ts-ignore
+                    mutateEvents(events.filter((e) => e.id != deletedEvent.id))
+                }
+            }
+            setFailure(null)
+            setSuccess("success")
+            setTimeout(() => {
+                setShowDeleteEventModal(false)
+                onClose()
+                setSuccess(null)
+            }, 2000)
+        }).catch((error) => {
+            console.error(error)
+            setSuccess(null)
+            setFailure("failure")
+            setTimeout(() => {
+                setFailure(null)
+            }, 2000)
+        })
+    }
+    
+
+    return (
+        <Modal
+            dismissible={true}
+            show={showDeleteEventModal}
+            onClose={onClose}
+            initialFocus={1}
+            size="xl"
+        >
+        <Modal.Header>
+            Delete Event
+        </Modal.Header>
+        <Modal.Body>
+            <Stack>
+            <h6>Are you sure you wish to delete: <b className="text-gray-900 dark:text-slate-400">{event?.name}</b> ? </h6>
+            <p className='text-red-400'>Warning! This action cannot be undone.</p>
+            <Button className="mt-4"
+                    color="failure"
+                    onClick={handleDeleteEvent}
+                    disabled={buttonDisabled}>
+                Delete Event
+            </Button>
+            { success && (
+                <Toast className=''>
+                    <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-green-100 text-green-500 dark:bg-green-800 dark:text-green-200">
+                        <HiCheckCircle className="h-5 w-5" />
+                    </div>
+                    <div className="ml-3 text-sm font-normal">
+                        Event Deleted
+                    </div>
+                </Toast>
+            )}
+            { failure && (
+                <Toast className=''>
+                    <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-red-100 text-red-500 dark:bg-red-800 dark:text-red-200">
+                        <HiX className="h-5 w-5" />
+                    </div>
+                    <div className="ml-3 text-sm font-normal">
+                        Error deleting event
+                    </div>
+                </Toast>
+            )}
+            </Stack>
+        </Modal.Body>
+        </Modal>
+      )
+    }
+    

--- a/lib/actions/deleteEvent.ts
+++ b/lib/actions/deleteEvent.ts
@@ -1,0 +1,18 @@
+import { basePath } from "lib/basePath"
+import { Event } from 'pages/api/event/[eventId]'
+import { Data } from 'pages/api/event/[eventId]'
+
+// function that returns a promise that does a DELETE request for this endpoint
+export const deleteEvent = async (event: Event): Promise<Data> => {
+    const apiPath = `${basePath}/api/event/${event.id}`
+    const requestOptions = {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event })
+  };
+  return fetch(apiPath, requestOptions)
+      .then(response => response.json()).then(data => {
+        if ('error' in data) throw data.error
+        if ('event' in data) return data.event
+    })
+}

--- a/pages/api/event/[eventId].ts
+++ b/pages/api/event/[eventId].ts
@@ -139,27 +139,17 @@ const eventHandler = async (
         res.status(401).json({ error: 'Unauthorized' });
         return;
     }
-    prisma.eventGroup.deleteMany({
-      // first we remove associated eventGroups
-      where: { eventId: parseInt(eventId) },
-    }).then(() => {
-      // remove associated userOnEvent
-      const x = prisma.userOnEvent.deleteMany({
-      where: { eventId: parseInt(eventId) },
-      }).then(() => {
-        // delete the event
-        const deletedEvent = prisma.event.delete({
-        where: { id: parseInt(eventId) },
-        include: { EventGroup: { include: { EventItem: true } }, UserOnEvent: { include: { user: true } } },
-        }).then((deletedEvent) => {
-          res.status(200).json({ event: deletedEvent });
-          return;
-        }).catch((error) => {
-            res.status(500).json({ error: 'Problem deleting event' });
-            return;
-          }) 
-      })
-    })  
+    // delete the event
+    const deletedEvent = prisma.event.delete({
+    where: { id: parseInt(eventId) },
+    include: { EventGroup: { include: { EventItem: true } }, UserOnEvent: { include: { user: true } } },
+    }).then((deletedEvent) => {
+      res.status(200).json({ event: deletedEvent });
+      return;
+    }).catch((error) => {
+      res.status(500).json({ error: 'Problem deleting event' });
+      return;
+    }) 
   // user not authorized
   } else {
     res.status(405).json({ error: 'Method not allowed' });

--- a/pages/api/event/[eventId].ts
+++ b/pages/api/event/[eventId].ts
@@ -139,13 +139,31 @@ const eventHandler = async (
         res.status(401).json({ error: 'Unauthorized' });
         return;
     }
-    const deletedEvent = await prisma.event.delete({
-      where: { id: parseInt(eventId) },
-      include: { EventGroup: { include: { EventItem: true } }, UserOnEvent: { include: { user: true } } },
-    });
-    res.status(200).json({ event: deletedEvent });
+    prisma.eventGroup.deleteMany({
+      // first we remove associated eventGroups
+      where: { eventId: parseInt(eventId) },
+    }).then(() => {
+      // remove associated userOnEvent
+      const x = prisma.userOnEvent.deleteMany({
+      where: { eventId: parseInt(eventId) },
+      }).then(() => {
+        // delete the event
+        const deletedEvent = prisma.event.delete({
+        where: { id: parseInt(eventId) },
+        include: { EventGroup: { include: { EventItem: true } }, UserOnEvent: { include: { user: true } } },
+        }).then((deletedEvent) => {
+          res.status(200).json({ event: deletedEvent });
+          return;
+        }).catch((error) => {
+            res.status(500).json({ error: 'Problem deleting event' });
+            return;
+          }) 
+      })
+    })  
+  // user not authorized
   } else {
     res.status(405).json({ error: 'Method not allowed' });
+    return;
   }
 }
 

--- a/prisma/migrations/20231110163442_cascade_event_deletes/migration.sql
+++ b/prisma/migrations/20231110163442_cascade_event_deletes/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "EventGroup" DROP CONSTRAINT "EventGroup_eventId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserOnEvent" DROP CONSTRAINT "UserOnEvent_eventId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "UserOnEvent" ADD CONSTRAINT "UserOnEvent_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EventGroup" ADD CONSTRAINT "EventGroup_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,7 +87,7 @@ enum EventStatus {
 model UserOnEvent {
   user      User?       @relation(fields: [userEmail], references: [email])
   userEmail String // relation scalar field (used in the `@relation` attribute above)
-  event     Event       @relation(fields: [eventId], references: [id])
+  event     Event       @relation(fields: [eventId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   eventId   Int // relation scalar field (used in the `@relation` attribute above)
   status    EventStatus @default(REQUEST)
 
@@ -118,9 +118,9 @@ model EventGroup {
   start         DateTime        @default(now())
   end           DateTime        @default(now())
   location      String          @default("")
-  event         Event           @relation(fields: [eventId], references: [id])
+  event         Event           @relation(fields: [eventId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   eventId       Int
-  EventItem     EventItem[]
+  EventItem     EventItem[]     
   CommentThread CommentThread[]
 }
 


### PR DESCRIPTION
Closes #50 

This adds a button to delete event, there is a conformation modal (with a time-locked delete button)

The one idiosyncracy is that the delete event api code requires me to first remove eventitems and then useronevent before i can delete the event db row. I think this can be done by reworked into using the prisma schema to use oncascade delete but this was the simplest option for now.

![delete_event](https://github.com/OxfordRSE/gutenberg/assets/60351846/0ffbe311-f1ae-4ad5-920c-0416710ecd99)
