### PR TITLE
Prevent problems with same tag being erroneuously ticked off with filter for section

### DIFF
--- a/components/EventProblems.tsx
+++ b/components/EventProblems.tsx
@@ -40,6 +40,7 @@ const EventProblems: React.FC<Props> = ({ material, event }) => {
     if (filteredProblems) {userProblems[user.userEmail] = filteredProblems;}
   });
   
+
   return (
     <Table className='border dark:border-gray-700'>
       <Table.Head>
@@ -85,7 +86,7 @@ const EventProblems: React.FC<Props> = ({ material, event }) => {
                       )}
                     </Table.Cell>
                     { students?.map((user, i) => {
-                        const problemStruct = userProblems[user.userEmail].find((p) => p.tag === problem)
+                        const problemStruct = userProblems[user.userEmail].find((p) => p.tag === problem && p.section === eventItem.section)
                         const problemStr = `difficulty: ${problemStruct?.difficulty} notes: ${problemStruct?.notes}`
                         return (
                           <Table.Cell key={`${user.userEmail}-${problem}-${eventItem.section}-${problem}`} align='center' className="whitespace-nowrap font-medium text-gray-900 dark:text-white p-0">


### PR DESCRIPTION
prevents duplicate problem tags from breaking table closes #89 

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/b488df96-7e3f-4fca-a880-ce1fd1f2c898)
note dot product is unticked despite sharing a tag between c++ & python