### PR TITLE
use localstorage for active events

### DIFF
--- a/cypress/component/CommentThread.cy.tsx
+++ b/cypress/component/CommentThread.cy.tsx
@@ -88,7 +88,7 @@ context ('with non-owner student', () => {
     cy.intercept(`/api/commentThread/${threadId}`, { commentThread: thread }).as("thread");
     cy.intercept(`/api/user/${createdByEmail}`, { user: createdByUser }).as("createdByUser");
     cy.intercept(`/api/user/${currentUserEmail}`, { user: currentUser }).as("currentUser");
-    cy.stub(sessionStorage, 'getItem').returns('1')
+    cy.stub(localStorage, 'getItem').returns('1')
     cy.intercept(`/api/event/1`, { event }).as("event");
     const setActiveSpy = cy.spy().as("setActive");
     const onDeleteSpy = cy.spy().as("onDelete");
@@ -238,7 +238,7 @@ context('with owner student', () => {
   beforeEach(() => {
     cy.intercept(`/api/commentThread/${threadId}`, { commentThread: thread }).as("thread");
     cy.intercept(`/api/user/${currentUserEmail}`, { user: currentUser }).as("currentUser");
-    cy.stub(sessionStorage, 'getItem').returns('1')
+    cy.stub(localStorage, 'getItem').returns('1')
     cy.intercept(`/api/event/1`, { event }).as("event");
     const setActiveSpy = cy.spy().as("setActive");
     const onDeleteSpy = cy.spy().as("onDelete");
@@ -346,7 +346,7 @@ context('with non-owner instructor', () => {
   beforeEach(() => {
     cy.intercept(`/api/commentThread/${threadId}`, { commentThread: thread }).as("thread");
     cy.intercept(`/api/user/${currentUserEmail}`, { user: currentUser }).as("currentUser");
-    cy.stub(sessionStorage, 'getItem').returns('1')
+    cy.stub(localStorage, 'getItem').returns('1')
     cy.intercept(`/api/event/1`, { event }).as("event");
     const setActiveSpy = cy.spy().as("setActive");
     const onDeleteSpy = cy.spy().as("onDelete");

--- a/lib/hooks/useActiveEvents.ts
+++ b/lib/hooks/useActiveEvents.ts
@@ -20,7 +20,7 @@ function useActiveEvent(): [EventFull | undefined, (event: EventFull | undefined
   }, [dispatch]);
 
   useEffect(() => {
-    const store = sessionStorage.getItem('activeEvent')
+    const store = localStorage.getItem('activeEvent')
     if (store) {
       setActiveEventId(parseInt(store))
     }
@@ -29,10 +29,10 @@ function useActiveEvent(): [EventFull | undefined, (event: EventFull | undefined
   useEffect(() => {
     const store = activeEventId?.toString();
     if (store) {
-      sessionStorage.setItem('activeEvent', store)
+      localStorage.setItem('activeEvent', store)
     }
     else {
-      sessionStorage.removeItem('activeEvent')
+      localStorage.removeItem('activeEvent')
     }
   }, [activeEventId])
 


### PR DESCRIPTION
We currently use sessionStorage to store activeEventId

This changes the storing of activeeventid to localstorage, this makes the site usability a lot higher (don't have to select event on each visit or in each tab.

In my opinion session storage still makes sense for the sidebar status.

closes #87 
