### PR TITLE
Small padding changes in markdown rendering

### DIFF
--- a/components/Callout.tsx
+++ b/components/Callout.tsx
@@ -6,7 +6,7 @@ interface ChallengeProps {
 
 const Callout: React.FC<ChallengeProps> = ({ content }) => {
   return (
-    <div className="my-4 px-2 border border-gray-200 rounded-lg bg-slate-50 dark:bg-slate-800 dark:border-gray-700">
+    <div className="my-4 px-2 border border-gray-200 rounded-lg bg-slate-50 dark:bg-slate-800 dark:border-gray-700 callout">
       {content}
     </div>
   )

--- a/components/content/Paragraph.tsx
+++ b/components/content/Paragraph.tsx
@@ -145,7 +145,7 @@ const Paragraph: React.FC<ParagraphProps> = ({ content, section }) => {
 
   return (
     <>
-      <div data-cy="paragraph" ref={ref} className="relative">
+      <div data-cy="paragraph" ref={ref} className="relative pb-2">
         {content}
         {activeEvent && (
           <div className={`absolute top-0 right-0 md:-right-6 xl:-right-[420px]`}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,3 +22,9 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   @apply bg-gray-700;
 }
+
+/* CSS to target the first h1 or h2 inside a Callout */
+.callout > h1:first-child,
+.callout > h2:first-child {
+  margin-top: 16px;
+}


### PR DESCRIPTION
Adds consistent padding for h1 and h2 for the first heading inside a callout. This is perhaps shortsighted as maybe someone wants to use h3? closes #132 

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/21455519-f9a7-4be0-84a3-bc62ae95a961)


Adds a small bottom pad to paragraphs so line breaks render as whitespace. closes #131 

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/ae4661e9-6f78-4339-bcc6-a0cbe31239e0)
