### PR TITLE
Fix enrol key for non admins

### DIFF
--- a/components/EnrolDialog.tsx
+++ b/components/EnrolDialog.tsx
@@ -82,7 +82,7 @@ const EnrolDialog: React.FC<Props> = ({ event, show, onEnrol }) => {
             } else if (status === "INSTRUCTOR") {
               newUser.status = EventStatus.INSTRUCTOR
             }
-            if (eventData) {
+            if (event) {
               putUserOnEvent(event.id, newUser).then(() => {
                 setKeySuccess("success")
                 setTimeout(() => {


### PR DESCRIPTION
Crazily I had never tested this with a non-admin account, turns out only admins can enrol because a useEvent hook can only be accessed by admins (and this event id was not available to a non-admin)

Non admins  can now enrol

closes #152 