### PR TITLE
Add E2E tests for using enrol keys

### DIFF
--- a/components/EnrolDialog.tsx
+++ b/components/EnrolDialog.tsx
@@ -112,17 +112,18 @@ const EnrolDialog: React.FC<Props> = ({ event, show, onEnrol }) => {
             <form onSubmit={handleSubmit(enrolWithKey)}>
               <Stack direction="row" spacing={2} className="justify-center flex-row">
                 <TextField
+                  data-cy={`key-enrol-input-${event.id}`}
                   textfieldProps={{ autoComplete: "off", placeholder: "Enrolment Key", autoFocus: true }}
                   name={"enrolKey"}
                   control={control}
                 />
-                <Button type="submit" className="m-0 h-10 mt-1">
+                <Button data-cy={`key-enrol-${event.id}`} type="submit" className="m-0 h-10 mt-1">
                   Enrol
                 </Button>
               </Stack>
             </form>
             {enrolError && (
-              <Toast className="">
+              <Toast data-cy={`enrol-failure-${event.id}`} className="">
                 <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-red-100 text-red-500 dark:bg-red-800 dark:text-red-200">
                   <HiX className="h-5 w-5" />
                 </div>
@@ -130,7 +131,7 @@ const EnrolDialog: React.FC<Props> = ({ event, show, onEnrol }) => {
               </Toast>
             )}
             {keySuccess && (
-              <Toast className="">
+              <Toast data-cy={`enrol-success-${event.id}`} className="">
                 <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-green-100 text-green-500 dark:bg-green-800 dark:text-green-200">
                   <HiCheckCircle className="h-5 w-5" />
                 </div>
@@ -141,7 +142,9 @@ const EnrolDialog: React.FC<Props> = ({ event, show, onEnrol }) => {
         </Modal.Body>
         <Modal.Footer>
           <p>If you have not received an enrolment key, you can request enrolment:</p>
-          <Button onClick={onClick}>Request Enrollment</Button>
+          <Button data-cy={`request-enrol-${event.id}`} onClick={onClick}>
+            Request Enrollment
+          </Button>
         </Modal.Footer>
       </Modal>
       {error && (

--- a/components/EventActions.tsx
+++ b/components/EventActions.tsx
@@ -75,8 +75,8 @@ const EventActions: React.FC<EventActionsProps> = ({ event }) => {
       ) : (
         session && (
           <>
-            <Button color="gray" onClick={handleEnrol(event)} style={{ zIndex: 1 }}>
-              Enroll
+            <Button color="gray" data-cy={`event-enrol-${event.id}`} onClick={handleEnrol(event)} style={{ zIndex: 1 }}>
+              Enrol
               <HiArrowNarrowRight className="ml-2 h-3 w-3" />
             </Button>
             <EnrolDialog event={event} show={showEvent == event} onEnrol={onEnrol} />

--- a/cypress/e2e/landing-page-admin.cy.js
+++ b/cypress/e2e/landing-page-admin.cy.js
@@ -4,6 +4,13 @@ describe("admin landing page", () => {
     email: "admin@localhost",
   }
 
+  const userOnEvent = {
+    userOnEvent: {
+      userEmail: "admin@localhost",
+      eventId: 1,
+    },
+  }
+
   beforeEach(() => {
     cy.visit("/")
     cy.login(user)
@@ -16,6 +23,34 @@ describe("admin landing page", () => {
 
   it("Delete event button exists", () => {
     cy.get('[data-cy*="delete-event"]').should("be.visible")
+  })
+
+  it("Admin Can Enrol With Key", () => {
+    cy.get('[data-cy="event-enrol-1"]').should("be.visible")
+    cy.get('[data-cy="event-enrol-1"]').click()
+    cy.get('[data-cy="key-enrol-1"]').should("be.visible")
+    cy.get("#enrolKey").type("testEnrol")
+    cy.get('[data-cy="key-enrol-1"]').click()
+    cy.get('[data-cy="enrol-success-1"]').should("be.visible")
+    // Then we remove the user just in case we want to run this test again locally
+    cy.request("DELETE", "/api/userOnEvent/1", userOnEvent)
+  })
+
+  it("Admin Can Enrol With Instructor Key", () => {
+    cy.get('[data-cy="event-enrol-1"]').should("be.visible")
+    cy.get('[data-cy="event-enrol-1"]').click()
+    cy.get('[data-cy="key-enrol-1"]').should("be.visible")
+    cy.get("#enrolKey").type("testInstructor")
+    cy.get('[data-cy="key-enrol-1"]').click()
+    cy.get('[data-cy="enrol-success-1"]').should("be.visible")
+    // check we are an instructor
+    cy.request("GET", "/api/userOnEvent/1").then((response) => {
+      const uOnE = response.body.userOnEvent
+      console.log(uOnE)
+      expect(uOnE.status).to.equal("INSTRUCTOR")
+    })
+    // Then we remove the user just in case we want to run this test again locally
+    cy.request("DELETE", "/api/userOnEvent/1", userOnEvent)
   })
 
   it("admin create/delete event", () => {

--- a/cypress/e2e/landing-page-admin.cy.js
+++ b/cypress/e2e/landing-page-admin.cy.js
@@ -53,6 +53,15 @@ describe("admin landing page", () => {
     cy.request("DELETE", "/api/userOnEvent/1", userOnEvent)
   })
 
+  it("Admin Can Not Enrol WithOut Key", () => {
+    cy.get('[data-cy="event-enrol-1"]').should("be.visible")
+    cy.get('[data-cy="event-enrol-1"]').click()
+    cy.get('[data-cy="key-enrol-1"]').should("be.visible")
+    cy.get("#enrolKey").type("not the enrol key")
+    cy.get('[data-cy="key-enrol-1"]').click()
+    cy.get('[data-cy="enrol-failure-1"]').should("be.visible")
+  })
+
   it("admin create/delete event", () => {
     cy.intercept("GET", "/api/auth/session").as("getSession")
 

--- a/cypress/e2e/landing-page-non-admin.cy.js
+++ b/cypress/e2e/landing-page-non-admin.cy.js
@@ -1,0 +1,63 @@
+describe("non admin landing page", () => {
+  const user = {
+    name: "notOnCourse",
+    email: "notOnCourse@localhost",
+  }
+
+  const userOnEvent = {
+    userOnEvent: {
+      userEmail: "notOnCourse@localhost",
+      eventId: 1,
+    },
+  }
+
+  beforeEach(() => {
+    cy.visit("/")
+    cy.login(user)
+    cy.visit("/")
+  })
+
+  it("Create event button does not exist", () => {
+    cy.contains("Create new Event").should("not.exist")
+  })
+  it("Delete event button does not exist", () => {
+    cy.get('[data-cy*="delete-event"]').should("not.exist")
+  })
+
+  it("Can Not Enrol WithOut Key", () => {
+    cy.get('[data-cy="event-enrol-1"]').should("be.visible")
+    cy.get('[data-cy="event-enrol-1"]').click()
+    cy.get('[data-cy="key-enrol-1"]').should("be.visible")
+    cy.get("#enrolKey").type("not the enrol key")
+    cy.get('[data-cy="key-enrol-1"]').click()
+    cy.get('[data-cy="enrol-failure-1"]').should("be.visible")
+  })
+
+  it("Can Enrol With Key", () => {
+    cy.get('[data-cy="event-enrol-1"]').should("be.visible")
+    cy.get('[data-cy="event-enrol-1"]').click()
+    cy.get('[data-cy="key-enrol-1"]').should("be.visible")
+    cy.get("#enrolKey").type("testEnrol")
+    cy.get('[data-cy="key-enrol-1"]').click()
+    cy.get('[data-cy="enrol-success-1"]').should("be.visible")
+    // Then we remove the user just in case we want to run this test again locally
+    cy.request("DELETE", "/api/userOnEvent/1", userOnEvent)
+  })
+
+  it("Can Enrol With Instructor Key", () => {
+    cy.get('[data-cy="event-enrol-1"]').should("be.visible")
+    cy.get('[data-cy="event-enrol-1"]').click()
+    cy.get('[data-cy="key-enrol-1"]').should("be.visible")
+    cy.get("#enrolKey").type("testInstructor")
+    cy.get('[data-cy="key-enrol-1"]').click()
+    cy.get('[data-cy="enrol-success-1"]').should("be.visible")
+    // check we are an instructor
+    cy.request("GET", "/api/userOnEvent/1").then((response) => {
+      const uOnE = response.body.userOnEvent
+      console.log(uOnE)
+      expect(uOnE.status).to.equal("INSTRUCTOR")
+    })
+    // Then we remove the user just in case we want to run this test again locally
+    cy.request("DELETE", "/api/userOnEvent/1", userOnEvent)
+  })
+})

--- a/lib/actions/deleteUserOnEvent.ts
+++ b/lib/actions/deleteUserOnEvent.ts
@@ -1,0 +1,23 @@
+import { basePath } from "lib/basePath"
+import { Data } from "pages/api/userOnEvent/[eventId]"
+import { UserOnEvent } from "@prisma/client"
+import { Event } from "lib/types"
+import { data } from "cypress/types/jquery"
+
+export const deleteUserOnEvent = async (userOnEvent: UserOnEvent): Promise<Event> => {
+  const eventId = userOnEvent.eventId
+  const apiPath = `${basePath}/api/userOnEvent/${eventId}`
+  const requestOptions = {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ userOnEvent }),
+  }
+  return fetch(apiPath, requestOptions)
+    .then((response) => response.json())
+    .then((data) => {
+      if ("error" in data) throw data.error
+      if ("userOnEvent" in data) return data.userOnEvent
+    })
+}
+
+export default deleteUserOnEvent

--- a/pages/api/userOnEvent/[eventId].ts
+++ b/pages/api/userOnEvent/[eventId].ts
@@ -85,8 +85,28 @@ const UserOnEvent = async (req: NextApiRequest, res: NextApiResponse<Data>) => {
         return
       }
       break
+    case "DELETE":
+      if (!isAdmin && userEmail !== req.body.userOnEvent.userEmail) {
+        res.status(401).json({ error: "Unauthorized" })
+        return
+      }
+      // remove user from event
+      userOnEvent = req.body.userOnEvent
+      const deletedUserOnEvent = prisma.userOnEvent
+        .delete({
+          where: { userEmail_eventId: { userEmail: userOnEvent.userEmail, eventId: userOnEvent.eventId } },
+        })
+        .then((deletedUserOnEvent) => {
+          res.status(200).json({ userOnEvent: deletedUserOnEvent })
+          return
+        })
+        .catch((error) => {
+          res.status(500).json({ error: "Problem deleting userOnEvent" })
+          return
+        })
+      break
     default:
-      res.setHeader("Allow", ["GET", "POST", "PUT"])
+      res.setHeader("Allow", ["GET", "POST", "PUT", "DELETE"])
       res.status(404).end(`Method ${method} Not Allowed`)
       break
   }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -48,6 +48,8 @@ async function main() {
       summary: "Introduction to the C++ programming language",
       start: new Date(2023, 7, 1, 9, 30),
       end: new Date(2023, 7, 2, 14, 0),
+      enrolKey: "testEnrol",
+      instructorKey: "testInstructor",
       hidden: false,
       EventGroup: {
         connectOrCreate: [


### PR DESCRIPTION
To prevent regression to #152 

This adds end 2 end tests for enrolling with keys as both user and instructor for both admin and regular user as well as an invalid key check for each.

closes #154 