### PR TITLE
Add callout styles

### DIFF
--- a/components/Callout.tsx
+++ b/components/Callout.tsx
@@ -2,13 +2,13 @@ import React, { useRef, useState } from "react"
 
 interface CalloutProps {
   content: React.ReactNode
-  calloutClass?: string
+  variant?: string
 }
 
-const Callout: React.FC<CalloutProps> = ({ content, calloutClass }) => {
+const Callout: React.FC<CalloutProps> = ({ content, variant }) => {
   return (
     <div
-      className={`my-4 px-2 border border-gray-200 rounded-lg bg-slate-50 dark:bg-slate-800 dark:border-gray-700 callout ${calloutClass}`}
+      className={`my-4 px-2 border border-gray-200 rounded-lg bg-slate-50 dark:bg-slate-800 dark:border-gray-700 callout ${variant}`}
     >
       {content}
     </div>

--- a/components/Callout.tsx
+++ b/components/Callout.tsx
@@ -1,12 +1,15 @@
 import React, { useRef, useState } from "react"
 
-interface ChallengeProps {
+interface CalloutProps {
   content: React.ReactNode
+  calloutClass?: string
 }
 
-const Callout: React.FC<ChallengeProps> = ({ content }) => {
+const Callout: React.FC<CalloutProps> = ({ content, calloutClass }) => {
   return (
-    <div className="my-4 px-2 border border-gray-200 rounded-lg bg-slate-50 dark:bg-slate-800 dark:border-gray-700 callout">
+    <div
+      className={`my-4 px-2 border border-gray-200 rounded-lg bg-slate-50 dark:bg-slate-800 dark:border-gray-700 callout ${calloutClass}`}
+    >
       {content}
     </div>
   )

--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -24,7 +24,6 @@ import { CodeComponent, CodeProps, ReactMarkdownProps } from "react-markdown/lib
 import Callout from "../Callout"
 import { Course, Section, Theme } from "lib/material"
 import Paragraph from "./Paragraph"
-import { List, ListItem } from "@mui/material"
 
 function reactMarkdownRemarkDirective() {
   return (tree: any) => {
@@ -61,8 +60,12 @@ function solution({ node, children, ...props }: ReactMarkdownProps) {
   return <Solution content={children} />
 }
 
-function callout({ node, children, ...props }: ReactMarkdownProps) {
-  return <Callout content={children} />
+type CalloutProps = ReactMarkdownProps & {
+  calloutClass: string
+}
+
+function callout({ node, children, calloutClass, ...props }: CalloutProps) {
+  return <Callout content={children} calloutClass={calloutClass} />
 }
 
 type ChallengeProps = ReactMarkdownProps & {

--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -61,7 +61,7 @@ function solution({ node, children, ...props }: ReactMarkdownProps) {
 }
 
 type CalloutProps = ReactMarkdownProps & {
-  calloutClass: string
+  variant: string
 }
 
 function callout({ node, children, calloutClass, ...props }: CalloutProps) {

--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -64,8 +64,8 @@ type CalloutProps = ReactMarkdownProps & {
   variant: string
 }
 
-function callout({ node, children, calloutClass, ...props }: CalloutProps) {
-  return <Callout content={children} calloutClass={calloutClass} />
+function callout({ node, children, variant, ...props }: CalloutProps) {
+  return <Callout content={children} variant={variant} />
 }
 
 type ChallengeProps = ReactMarkdownProps & {

--- a/styles/callouts.css
+++ b/styles/callouts.css
@@ -24,19 +24,19 @@ div.callout.warning::before {
   content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0 WARNING";
 }
 
-/* Caution */
-div.callout.caution > h1.first-child,
-div.callout.caution > h2.first-child,
-div.callout.caution > h3.first-child {
+/* danger */
+div.callout.danger > h1.first-child,
+div.callout.danger > h2.first-child,
+div.callout.danger > h3.first-child {
   @apply mt-0;
 }
 
-div.callout.caution {
+div.callout.danger {
   @apply border-r-0 border-t-0 border-b-0 rounded-none;
   border-left: 6px #dc0000 solid;
 }
 
-div.callout.caution {
+div.callout.danger {
   background-image: url("https://icongr.am/octicons/flame.svg?size=128&color=dc0000");
   background-position: 0.5rem 0.4rem;
   background-size: 1.5rem 1.5rem;
@@ -44,9 +44,9 @@ div.callout.caution {
   padding-top: 0.36rem;
 }
 
-div.callout.caution::before {
+div.callout.danger::before {
   color: #dc0000;
-  content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0 CAUTION";
+  content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0 DANGER";
 }
 
 /* Note */

--- a/styles/callouts.css
+++ b/styles/callouts.css
@@ -1,0 +1,150 @@
+/* Callouts in markdown Content */
+/* Warning */
+div.callout.warning > h1.first-child,
+div.callout.warning > h2.first-child,
+div.callout.warning > h3.first-child {
+  @apply mt-0;
+}
+
+div.callout.warning {
+  @apply border-r-0 border-t-0 border-b-0 rounded-none;
+  border-left: 6px #ff5500 solid;
+}
+
+div.callout.warning {
+  background-image: url("https://icongr.am/octicons/alert.svg?size=128&color=ff5500");
+  background-position: 0.5rem 0.4rem;
+  background-size: 1.5rem 1.5rem;
+  background-repeat: no-repeat;
+  padding-top: 0.36rem;
+}
+
+div.callout.warning::before {
+  color: #ff5500;
+  content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0 WARNING";
+}
+
+/* Caution */
+div.callout.caution > h1.first-child,
+div.callout.caution > h2.first-child,
+div.callout.caution > h3.first-child {
+  @apply mt-0;
+}
+
+div.callout.caution {
+  @apply border-r-0 border-t-0 border-b-0 rounded-none;
+  border-left: 6px #dc0000 solid;
+}
+
+div.callout.caution {
+  background-image: url("https://icongr.am/octicons/flame.svg?size=128&color=dc0000");
+  background-position: 0.5rem 0.4rem;
+  background-size: 1.5rem 1.5rem;
+  background-repeat: no-repeat;
+  padding-top: 0.36rem;
+}
+
+div.callout.caution::before {
+  color: #dc0000;
+  content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0 CAUTION";
+}
+
+/* Note */
+div.callout.note > h1.first-child,
+div.callout.note > h2.first-child,
+div.callout.note > h3.first-child {
+  @apply mt-0;
+}
+
+div.callout.note {
+  @apply border-r-0 border-t-0 border-b-0 rounded-none;
+  border-left: 6px #005cc5 solid;
+}
+
+div.callout.note {
+  background-image: url("https://icongr.am/octicons/report.svg?size=128&color=005cc5");
+  background-position: 0.5rem 0.4rem;
+  background-size: 1.5rem 1.5rem;
+  background-repeat: no-repeat;
+  padding-top: 0.36rem;
+}
+
+div.callout.note::before {
+  color: #005cc5;
+  content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0 NOTE";
+}
+
+/* Tip */
+div.callout.tip > h1.first-child,
+div.callout.tip > h2.first-child,
+div.callout.tip > h3.first-child {
+  @apply mt-0;
+}
+
+div.callout.tip {
+  @apply border-r-0 border-t-0 border-b-0 rounded-none;
+  border-left: 6px #00b265 solid;
+}
+
+div.callout.tip {
+  background-image: url("https://icongr.am/octicons/light-bulb.svg?size=128&color=00b265");
+  background-position: 0.5rem 0.4rem;
+  background-size: 1.5rem 1.5rem;
+  background-repeat: no-repeat;
+  padding-top: 0.36rem;
+}
+
+div.callout.tip::before {
+  color: #00b265;
+  content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0 TIP";
+}
+
+/* Key Points */
+div.callout.keypoints > h1.first-child,
+div.callout.keypoints > h2.first-child,
+div.callout.keypoints > h3.first-child {
+  @apply mt-0;
+}
+
+div.callout.keypoints {
+  @apply border-r-0 border-t-0 border-b-0 rounded-none;
+  border-left: 6px #a400c5 solid;
+}
+
+div.callout.keypoints {
+  background-image: url("https://icongr.am/octicons/bookmark.svg?size=128&color=a400c5");
+  background-position: 0.5rem 0.4rem;
+  background-size: 1.5rem 1.5rem;
+  background-repeat: no-repeat;
+  padding-top: 0.36rem;
+}
+
+div.callout.keypoints::before {
+  color: #a400c5;
+  content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0 KEY POINTS";
+}
+
+/* Discussion */
+div.callout.discussion > h1.first-child,
+div.callout.discussion > h2.first-child,
+div.callout.discussion > h3.first-child {
+  @apply mt-0;
+}
+
+div.callout.discussion {
+  @apply border-r-0 border-t-0 border-b-0 rounded-none;
+  border-left: 6px #00ffee solid;
+}
+
+div.callout.discussion {
+  background-image: url("https://icongr.am/octicons/comment-discussion.svg?size=128&color=00ffee");
+  background-position: 0.5rem 0.4rem;
+  background-size: 1.5rem 1.5rem;
+  background-repeat: no-repeat;
+  padding-top: 0.36rem;
+}
+
+div.callout.discussion::before {
+  color: #00ffee;
+  content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0 DISCUSSION";
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,4 @@
+@import "callouts.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
As we were discussing in #142 , this adds a few callout "styles" available when writing markdown, these don't all have to stay and we don't have to be limited to these but just as an idea:

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/8cc43479-2b13-4d40-8f1a-7e9859c7f56d)

I am hotlinking octicon icons which is fine, but could add it to the repo or find some mui icons or something.
