### PR TITLE
Hiding of older events

### DIFF
--- a/components/EventsView.tsx
+++ b/components/EventsView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react"
 import { Material } from "lib/material"
 import { EventFull, Event } from "lib/types"
 import { Button, Timeline } from "flowbite-react"
+import { BiArrowToBottom, BiArrowToTop } from "react-icons/bi"
 import EventActions from "./EventActions"
 import Link from "next/link"
 import useEvents from "lib/hooks/useEvents"
@@ -23,6 +24,9 @@ type EventsProps = {
 const EventsView: React.FC<EventsProps> = ({ material, events }) => {
   // don't show date/time until the page is loaded (due to rehydration issues)
   const [showDateTime, setShowDateTime] = useState(false)
+  const [oldEvents, setOldEvents] = useState(0)
+  const [newEvents, setNewEvents] = useState(0)
+  const [activeEvent] = useActiveEvent()
   const [showDeleteEventModal, setShowDeleteEventModal] = useRecoilState(deleteEventModalState)
   const [deleteEventId, setDeleteEventId] = useRecoilState(deleteEventIdState)
   const [showDuplicateEventModal, setShowDuplicateEventModal] = useRecoilState(duplicateEventModalState)
@@ -30,6 +34,11 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
 
   useEffect(() => {
     setShowDateTime(true)
+    var cutOffDate = new Date()
+    // we automatically hide events older than 2 months
+    cutOffDate.setMonth(cutOffDate.getMonth() - 2)
+    setOldEvents(events.filter((event) => event.start < cutOffDate).length)
+    setNewEvents(events.filter((event) => event.start >= cutOffDate).length)
   }, [])
 
   const { events: currentEvents, mutate } = useEvents()
@@ -41,6 +50,7 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
 
   for (let i = 0; i < events.length; i++) {
     events[i].start = new Date(events[i].start)
+    events[i].end = new Date(events[i].end)
   }
 
   // sort events by start date
@@ -68,48 +78,98 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
     setDuplicateEventId(eventId)
   }
 
+  const loadMoreEvents = () => {
+    setOldEvents(Math.max(oldEvents - 3, 0))
+  }
+
+  const hideMoreEvents = () => {
+    setOldEvents(Math.min(oldEvents + 3, events.length - newEvents))
+  }
+
   return (
     <Timeline>
-      {events.map((event) => {
-        return (
-          <Timeline.Item key={event.id}>
+      <Stack direction="row" className="mb-4">
+        {oldEvents > 0 ? (
+          <Timeline.Item>
             <Timeline.Point />
             <Timeline.Content>
-              <Timeline.Time className="flex justify-between">
-                <Link href={`/event/${event.id}`}>
-                  {showDateTime && event.start.toLocaleString([], { dateStyle: "medium", timeStyle: "short" })}
-                </Link>
-                {isAdmin && (
-                  <Stack direction="row">
-                    <Tooltip title="Duplicate Event">
-                      <MdContentCopy
-                        className="ml-2 inline flex cursor-pointer"
-                        data-cy={`duplicate-event-${event.id}`}
-                        size={18}
-                        onClick={() => openDuplicateEventModal(event.id)}
-                      />
-                    </Tooltip>
-                    <Tooltip title="Delete Event">
-                      <MdDelete
-                        className="ml-2 inline text-red-500 flex cursor-pointer"
-                        data-cy={`delete-event-${event.id}`}
-                        size={18}
-                        onClick={() => openDeleteEventModal(event.id)}
-                      />
-                    </Tooltip>
-                  </Stack>
-                )}
-              </Timeline.Time>
               <Timeline.Title>
-                <Link href={`/event/${event.id}`}>{event.name}</Link>
+                <Tooltip title="Show older events">
+                  <Button color="gray" size="xs" onClick={loadMoreEvents}>
+                    <BiArrowToTop />
+                  </Button>
+                </Tooltip>
               </Timeline.Title>
-              <Timeline.Body>
-                <Link href={`/event/${event.id}`}>{event.summary}</Link>
-              </Timeline.Body>
-              <EventActions event={event} />
             </Timeline.Content>
           </Timeline.Item>
-        )
+        ) : (
+          <Timeline.Item>
+            <Timeline.Point />
+            <Timeline.Content>
+              <Timeline.Title>
+                <div style={{ width: "34px", height: "20px" }}></div>
+              </Timeline.Title>
+            </Timeline.Content>
+          </Timeline.Item>
+        )}
+        {oldEvents < events.length - newEvents && (
+          <Timeline.Item>
+            <Timeline.Point />
+            <Timeline.Content>
+              <Timeline.Title>
+                <Tooltip title="Hide older events">
+                  <Button color="gray" size="xs" onClick={hideMoreEvents}>
+                    <BiArrowToBottom />
+                  </Button>
+                </Tooltip>
+              </Timeline.Title>
+            </Timeline.Content>
+          </Timeline.Item>
+        )}
+      </Stack>
+      {events.map((event, idx) => {
+        // only show events that are not older than 2 months unless they are the active event
+        if (idx - oldEvents >= 0 || event.id === activeEvent?.id) {
+          return (
+            <Timeline.Item key={event.id}>
+              <Timeline.Point />
+              <Timeline.Content>
+                <Timeline.Time className="flex justify-between">
+                  <Link href={`/event/${event.id}`}>
+                    {showDateTime && event.start.toLocaleString([], { dateStyle: "medium", timeStyle: "short" })}
+                  </Link>
+                  {isAdmin && (
+                    <Stack direction="row">
+                      <Tooltip title="Duplicate Event">
+                        <MdContentCopy
+                          className="ml-2 inline flex cursor-pointer"
+                          data-cy={`duplicate-event-${event.id}`}
+                          size={18}
+                          onClick={() => openDuplicateEventModal(event.id)}
+                        />
+                      </Tooltip>
+                      <Tooltip title="Delete Event">
+                        <MdDelete
+                          className="ml-2 inline text-red-500 flex cursor-pointer"
+                          data-cy={`delete-event-${event.id}`}
+                          size={18}
+                          onClick={() => openDeleteEventModal(event.id)}
+                        />
+                      </Tooltip>
+                    </Stack>
+                  )}
+                </Timeline.Time>
+                <Timeline.Title>
+                  <Link href={`/event/${event.id}`}>{event.name}</Link>
+                </Timeline.Title>
+                <Timeline.Body>
+                  <Link href={`/event/${event.id}`}>{event.summary}</Link>
+                </Timeline.Body>
+                <EventActions event={event} />
+              </Timeline.Content>
+            </Timeline.Item>
+          )
+        }
       })}
       {userProfile?.admin && (
         <Timeline.Item>

--- a/components/EventsView.tsx
+++ b/components/EventsView.tsx
@@ -95,7 +95,7 @@ const EventsView: React.FC<EventsProps> = ({ material, events }) => {
             <Timeline.Content>
               <Timeline.Title>
                 <Tooltip title="Show older events">
-                  <Button color="gray" size="xs" onClick={loadMoreEvents}>
+                  <Button color="gray" size="xs" onClick={loadMoreEvents} data-cy="load-more-events">
                     <BiArrowToTop />
                   </Button>
                 </Tooltip>

--- a/cypress/e2e/landing-page-admin.cy.js
+++ b/cypress/e2e/landing-page-admin.cy.js
@@ -17,15 +17,28 @@ describe("admin landing page", () => {
     cy.visit("/")
   })
 
+  it("Load more events works", () => {
+    cy.get('[data-cy="load-more-events"]').should("be.visible")
+    cy.get('[data-cy="event-enrol-1"]').should('not.exist')
+    cy.get('[data-cy="load-more-events"]')
+      .click()
+      .then(() => {
+        cy.get('[data-cy="event-enrol-1"]').should("be.visible")
+      })
+  })
+
   it("Create event button exists", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.contains("Create new Event").should("be.visible")
   })
 
   it("Delete event button exists", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.get('[data-cy*="delete-event"]').should("be.visible")
   })
 
   it("Admin Can Enrol With Key", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.get('[data-cy="event-enrol-1"]').should("be.visible")
     cy.get('[data-cy="event-enrol-1"]').click()
     cy.get('[data-cy="key-enrol-1"]').should("be.visible")
@@ -37,6 +50,7 @@ describe("admin landing page", () => {
   })
 
   it("Admin Can Enrol With Instructor Key", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.get('[data-cy="event-enrol-1"]').should("be.visible")
     cy.get('[data-cy="event-enrol-1"]').click()
     cy.get('[data-cy="key-enrol-1"]').should("be.visible")
@@ -54,6 +68,7 @@ describe("admin landing page", () => {
   })
 
   it("Admin Can Not Enrol WithOut Key", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.get('[data-cy="event-enrol-1"]').should("be.visible")
     cy.get('[data-cy="event-enrol-1"]').click()
     cy.get('[data-cy="key-enrol-1"]').should("be.visible")
@@ -63,6 +78,7 @@ describe("admin landing page", () => {
   })
 
   it("admin create/delete event", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.intercept("GET", "/api/auth/session").as("getSession")
 
     cy.request("GET", "/api/event").its("body").its("events").as("oldres")

--- a/cypress/e2e/landing-page-admin.cy.js
+++ b/cypress/e2e/landing-page-admin.cy.js
@@ -19,7 +19,7 @@ describe("admin landing page", () => {
 
   it("Load more events works", () => {
     cy.get('[data-cy="load-more-events"]').should("be.visible")
-    cy.get('[data-cy="event-enrol-1"]').should('not.exist')
+    cy.get('[data-cy="event-enrol-1"]').should("not.exist")
     cy.get('[data-cy="load-more-events"]')
       .click()
       .then(() => {

--- a/cypress/e2e/landing-page-non-admin.cy.js
+++ b/cypress/e2e/landing-page-non-admin.cy.js
@@ -25,6 +25,7 @@ describe("non admin landing page", () => {
   })
 
   it("Can Not Enrol WithOut Key", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.get('[data-cy="event-enrol-1"]').should("be.visible")
     cy.get('[data-cy="event-enrol-1"]').click()
     cy.get('[data-cy="key-enrol-1"]').should("be.visible")
@@ -34,6 +35,7 @@ describe("non admin landing page", () => {
   })
 
   it("Can Enrol With Key", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.get('[data-cy="event-enrol-1"]').should("be.visible")
     cy.get('[data-cy="event-enrol-1"]').click()
     cy.get('[data-cy="key-enrol-1"]').should("be.visible")
@@ -45,6 +47,7 @@ describe("non admin landing page", () => {
   })
 
   it("Can Enrol With Instructor Key", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.get('[data-cy="event-enrol-1"]').should("be.visible")
     cy.get('[data-cy="event-enrol-1"]').click()
     cy.get('[data-cy="key-enrol-1"]').should("be.visible")

--- a/cypress/e2e/landing-page.cy.js
+++ b/cypress/e2e/landing-page.cy.js
@@ -11,6 +11,7 @@ describe("landing page", () => {
     cy.contains("Create new Event").should("not.exist")
   })
   it("Delete event button does not exist", () => {
+    cy.get('[data-cy="load-more-events"]').click()
     cy.get('[data-cy*="delete-event"]').should("not.exist")
   })
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,7 +24,7 @@ const Home: NextPage<HomeProps> = ({ material, events, pageInfo }) => {
   return (
     <Layout material={material} pageInfo={pageInfo}>
       <div className="px-2 md:px-10 lg:px-10 xl:px-20 2xl:px-32  grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
-        <Card>
+        <Card className="scroll" style={{ maxHeight: "82vh", overflowY: "auto" }}>
           <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">Course Events</h5>
           <p className="font-normal text-gray-700 dark:text-gray-400">
             Login to request a place on an upcoming course, or to select an active course.


### PR DESCRIPTION
can view them now with a button.

activeevent is always shown and anything that ended > 2months ago is automatically hidden, otherwise show and hide more events buttons will increase/decrease visible events by 3 until all are visible.

The card that contains the timeline is now scrollable, with a max height of 80% of the viewport HOWEVER since the header and footer and fixed size this does mean the actual page appearance still depends on resolution (and mobile devices dont respect viewport height anyway)

![older_events2](https://github.com/OxfordRSE/gutenberg/assets/60351846/27467444-4145-467a-b3ab-8c6c9baafe05)

closes #141 