### PR TITLE
Add nav links to section page for dependsOn sections

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,26 +14,16 @@ interface Props {
   pageInfo?: PageTemplate
 }
 
-const Footer: React.FC<Props> = ({ prevUrl, nextUrl, pageInfo }) => {
+const Footer: React.FC<Props> = ({ pageInfo }) => {
   const footerAttrib = pageInfo?.footer
   return (
     <footer className="mt-4 mb-2 mx-2 p-2 bg-white rounded-lg shadow md:flex md:items-center md:justify-between dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
-      {prevUrl && (
-        <a href={`/material/${prevUrl}`} className="pointer-events-auto text-gray-500 hover:text-gray-400">
-          <HiArrowCircleLeft className="w-14 h-14" />
-        </a>
-      )}
       <span className="flex flex-wrap text-sm text-gray-500 sm:text-center dark:text-gray-400">
         {footerAttrib && <Markdown markdown={"© " + new Date().getFullYear() + " " + footerAttrib} />}
       </span>
       <p className="flex flex-wrap items-center mt-3 text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
         For attribution and license information click the @ symbol on the top right
       </p>
-      {nextUrl && (
-        <a href={`/material/${nextUrl}`} className="pointer-events-auto text-gray-600 hover:text-gray-500 opacity-50">
-          <HiArrowCircleRight className="w-14 h-14" />
-        </a>
-      )}
       <ThemeButton />
     </footer>
   )

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -35,7 +35,7 @@ const Layout: React.FC<Props> = ({ material, theme, course, section, children, p
   const [sidebarOpen, setSidebarOpen] = useSidebarOpen(true)
 
   const sectionLinks: SectionLink[] = findLinks(material, theme, course, section, activeEvent)
-
+  console.log(sectionLinks)
   return (
     <RecoilRoot>
       <div className="container mx-auto">

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -32,7 +32,22 @@ const Layout: React.FC<Props> = ({ material, theme, course, section, children, p
   const [showAttribution, setShowAttribution] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useSidebarOpen(true)
 
-  const pageLabel = `${theme?.id}.${course?.id}${section ? `.${section.id}` : ""}`
+  const findParents = (): String[] | undefined => {
+    const parents = []
+    const pageLabelShort = pageLabel.split(".").slice(1, pageLabel.split(".").length).join(".")
+    console.log(pageLabelShort)
+    console.log(course?.sections)
+    if (course?.sections != undefined) {
+      for (const sec of course?.sections) {
+        if (sec.dependsOn.includes(pageLabelShort)) {
+          parents.push(sec.id)
+        }
+      }
+      return parents
+    }
+  }
+
+  const pageLabel = `${theme?.repo}.${theme?.id}.${course?.id}${section ? `.${section.id}` : ""}`
 
   // check if this section is part of the active event
   let isInEvent = false
@@ -56,6 +71,18 @@ const Layout: React.FC<Props> = ({ material, theme, course, section, children, p
             nextUrl = nextItem.section.replaceAll(".", "/")
           }
         }
+      }
+    }
+  } else {
+    // if there is no active event we can still show the prev/next buttons if there is a linear path
+    if (section?.dependsOn.length == 1) {
+      prevUrl = `${theme?.repo}/${section?.dependsOn[0].replaceAll(".", "/")}`
+    }
+    if (section) {
+      const parents = findParents()
+      console.log(parents)
+      if (parents?.length == 1) {
+        nextUrl = `${theme?.repo}/${theme?.id}/${course?.id}/${parents[0]}`
       }
     }
   }

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -35,7 +35,6 @@ const Layout: React.FC<Props> = ({ material, theme, course, section, children, p
   const [sidebarOpen, setSidebarOpen] = useSidebarOpen(true)
 
   const sectionLinks: SectionLink[] = findLinks(material, theme, course, section, activeEvent)
-  console.log(sectionLinks)
   return (
     <RecoilRoot>
       <div className="container mx-auto">

--- a/components/Overlay.tsx
+++ b/components/Overlay.tsx
@@ -12,6 +12,7 @@ import { DeleteEventModal, deleteEventModalState } from "components/deleteEventM
 import { DuplicateEventModal, duplicateEventModalState } from "components/DuplicateEventModal"
 import { LinkedSection, SectionLink } from "./ui/LinkedSection"
 import { Stack } from "@mui/material"
+import useWindowSize from "lib/hooks/useWindowSize"
 
 interface Props {
   material: Material
@@ -42,7 +43,7 @@ const Overlay: NextPage<Props> = ({
   const [showTopButtons, setShowTopButtons] = useState(false)
   const [showDeleteEventModal, setShowDeleteEventModal] = useRecoilState(deleteEventModalState)
   const [showDuplicateEventModal, setShowDuplicateEventModal] = useRecoilState(duplicateEventModalState)
-
+  const windowSize = useWindowSize()
   // remove duplicate links in case activeevent includes the same section as dependsOn, reverse so AE comes first
   sectionLinks = sectionLinks
     ?.filter((item, index, array) => array.findIndex((other) => other.url === item.url) === index)
@@ -99,12 +100,18 @@ const Overlay: NextPage<Props> = ({
             className="pointer-events-auto absolute top-0 right-0 cursor-pointer w-12 h-12 text-gray-600 hover:text-gray-500 opacity-50"
           />
         )}
-        <Stack direction="column" className="absolute bottom-20 left-0 ">
-          {sectionLinks && sectionLinks.filter((link) => link.direction === "prev").map((link) => LinkedSection(link))}
-        </Stack>
-        <Stack direction="column" className="absolute bottom-20 right-0 ">
-          {sectionLinks && sectionLinks.filter((link) => link.direction === "next").map((link) => LinkedSection(link))}
-        </Stack>
+        {(windowSize?.width ?? 1024) >= 1024 && (
+          <>
+            <Stack direction="column" className="absolute bottom-20 left-0 ">
+              {sectionLinks &&
+                sectionLinks.filter((link) => link.direction === "prev").map((link) => LinkedSection(link))}
+            </Stack>
+            <Stack direction="column" className="absolute bottom-20 right-0 ">
+              {sectionLinks &&
+                sectionLinks.filter((link) => link.direction === "next").map((link) => LinkedSection(link))}
+            </Stack>
+          </>
+        )}
         <AttributionDialog citations={attribution} isOpen={showAttribution} onClose={closeAttribution} />
         <SearchDialog onClose={closeSearch} />
         <DeleteEventModal onClose={closeDeleteEvent} />

--- a/components/Overlay.tsx
+++ b/components/Overlay.tsx
@@ -11,6 +11,8 @@ import { useRecoilState } from "recoil"
 import { DeleteEventModal, deleteEventModalState } from "components/deleteEventModal"
 import { DuplicateEventModal, duplicateEventModalState } from "components/DuplicateEventModal"
 import { LinkedSection, SectionLink } from "./ui/LinkedSection"
+import { Stack } from "@mui/material"
+
 interface Props {
   material: Material
   theme?: Theme
@@ -40,6 +42,11 @@ const Overlay: NextPage<Props> = ({
   const [showTopButtons, setShowTopButtons] = useState(false)
   const [showDeleteEventModal, setShowDeleteEventModal] = useRecoilState(deleteEventModalState)
   const [showDuplicateEventModal, setShowDuplicateEventModal] = useRecoilState(duplicateEventModalState)
+
+  // remove duplicate links in case activeevent includes the same section as dependsOn, reverse so AE comes first
+  sectionLinks = sectionLinks
+    ?.filter((item, index, array) => array.findIndex((other) => other.url === item.url) === index)
+    .reverse()
 
   useEffect(() => {
     const handleScroll = () => {
@@ -92,7 +99,12 @@ const Overlay: NextPage<Props> = ({
             className="pointer-events-auto absolute top-0 right-0 cursor-pointer w-12 h-12 text-gray-600 hover:text-gray-500 opacity-50"
           />
         )}
-        <>{sectionLinks && sectionLinks.map((link) => LinkedSection(link))}</>
+        <Stack direction="column" className="absolute bottom-20 left-0 ">
+          {sectionLinks && sectionLinks.filter((link) => link.direction === "prev").map((link) => LinkedSection(link))}
+        </Stack>
+        <Stack direction="column" className="absolute bottom-20 right-0 ">
+          {sectionLinks && sectionLinks.filter((link) => link.direction === "next").map((link) => LinkedSection(link))}
+        </Stack>
         <AttributionDialog citations={attribution} isOpen={showAttribution} onClose={closeAttribution} />
         <SearchDialog onClose={closeSearch} />
         <DeleteEventModal onClose={closeDeleteEvent} />

--- a/components/Overlay.tsx
+++ b/components/Overlay.tsx
@@ -10,7 +10,7 @@ import { SearchDialog, searchQueryState } from "components/SearchDialog"
 import { useRecoilState } from "recoil"
 import { DeleteEventModal, deleteEventModalState } from "components/deleteEventModal"
 import { DuplicateEventModal, duplicateEventModalState } from "components/DuplicateEventModal"
-
+import { LinkedSection, SectionLink } from "./ui/LinkedSection"
 interface Props {
   material: Material
   theme?: Theme
@@ -21,8 +21,7 @@ interface Props {
   setShowAttribution: (show: boolean) => void
   sidebarOpen: boolean
   setSidebarOpen: (open: boolean) => void
-  prevUrl?: string
-  nextUrl?: string
+  sectionLinks?: SectionLink[]
 }
 
 const Overlay: NextPage<Props> = ({
@@ -35,8 +34,7 @@ const Overlay: NextPage<Props> = ({
   setShowAttribution,
   sidebarOpen,
   setSidebarOpen,
-  prevUrl,
-  nextUrl,
+  sectionLinks,
 }: Props) => {
   const [showSearch, setShowSearch] = useRecoilState(searchQueryState)
   const [showTopButtons, setShowTopButtons] = useState(false)
@@ -94,22 +92,7 @@ const Overlay: NextPage<Props> = ({
             className="pointer-events-auto absolute top-0 right-0 cursor-pointer w-12 h-12 text-gray-600 hover:text-gray-500 opacity-50"
           />
         )}
-        {prevUrl && (
-          <a
-            href={`/material/${prevUrl}`}
-            className="pointer-events-auto absolute bottom-20 left-0 text-gray-600 hover:text-gray-500 opacity-50"
-          >
-            <HiArrowCircleLeft className="w-14 h-14" />
-          </a>
-        )}
-        {nextUrl && (
-          <a
-            href={`/material/${nextUrl}`}
-            className="pointer-events-auto absolute bottom-20 right-0 text-gray-600 hover:text-gray-500 opacity-50"
-          >
-            <HiArrowCircleRight className="w-14 h-14" />
-          </a>
-        )}
+        <>{sectionLinks && sectionLinks.map((link) => LinkedSection(link))}</>
         <AttributionDialog citations={attribution} isOpen={showAttribution} onClose={closeAttribution} />
         <SearchDialog onClose={closeSearch} />
         <DeleteEventModal onClose={closeDeleteEvent} />

--- a/components/ui/LinkedSection.tsx
+++ b/components/ui/LinkedSection.tsx
@@ -1,4 +1,3 @@
-
 import { Section } from "lib/material"
 import { HiArrowCircleLeft, HiArrowCircleRight, HiChevronLeft, HiChevronRight } from "react-icons/hi"
 import Stack from "./Stack"

--- a/components/ui/LinkedSection.tsx
+++ b/components/ui/LinkedSection.tsx
@@ -1,5 +1,4 @@
-import { Section } from "lib/material"
-import { HiArrowCircleLeft, HiArrowCircleRight, HiChevronLeft, HiChevronRight } from "react-icons/hi"
+import { HiChevronLeft, HiChevronRight } from "react-icons/hi"
 import Stack from "./Stack"
 import React, { SyntheticEvent, useRef } from "react"
 import { Tooltip } from "@mui/material"
@@ -46,68 +45,44 @@ export const LinkedSection = (sectionLink: SectionLink) => {
     (sectionLink.course ? sectionLink.course + " - " : "") +
     (sectionLink.section ? sectionLink.section : "")
 
+  let stackDirection
+  let navIcon
   if (sectionLink.direction === "prev") {
-    return (
-      <Tooltip title={tooltipTitle}>
-        <a href={`${sectionLink.url}`} className={`pointer-events-auto text-gray-600 hover:text-gray-500 opacity-50`}>
-          <div
-            className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[55px] w-[170px] -ml-2 text-sm`}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-          >
-            <Stack spacing={4} direction="row">
-              <div style={{ marginLeft: "2px" }}>
-                {sectionLink.theme && (
-                  <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">
-                    {trimString(sectionLink.theme, 21)}
-                  </p>
-                )}
-                {sectionLink.course && (
-                  <p className="text-slate-600 dark:text-slate-300 text-xs"> {trimString(sectionLink.course, 21)} </p>
-                )}
-                {sectionLink.section && (
-                  <p className="text-slate-700 dark:text-slate-400">
-                    {trimString(sectionLink.section, 16)} {sectionLink.tags && `[${sectionLink.tags.join(", ")}]`}
-                  </p>
-                )}
-              </div>
-
-              <HiChevronLeft className="nav-chevron mt-3 h-6 w-5" style={{ color: iconColor }} />
-            </Stack>
-          </div>
-        </a>
-      </Tooltip>
-    )
-  } else if (sectionLink.direction === "next") {
-    return (
-      <Tooltip title={tooltipTitle}>
-        <a href={`${sectionLink.url}`} className={`pointer-events-auto text-gray-600 hover:text-gray-500 opacity-50`}>
-          <div
-            className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[55px] w-[170px] -ml-2 text-sm`}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-          >
-            <Stack spacing={4} direction="row">
-              <HiChevronRight className="nav-chevron mt-3 h-6 w-5" style={{ color: iconColor }} />
-              <div className="w-[140px]" style={{ marginLeft: "2px" }}>
-                {sectionLink.theme && (
-                  <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">
-                    {trimString(sectionLink.theme, 21)}
-                  </p>
-                )}
-                {sectionLink.course && (
-                  <p className="text-slate-600 dark:text-slate-300 text-xs">{trimString(sectionLink.course, 21)}</p>
-                )}
-                {sectionLink.section && (
-                  <p className="text-slate-700 dark:text-slate-400">
-                    {trimString(sectionLink.section, 16)} {sectionLink.tags && `[${sectionLink.tags.join(", ")}]`}
-                  </p>
-                )}
-              </div>
-            </Stack>
-          </div>
-        </a>
-      </Tooltip>
-    )
+    stackDirection = "row"
+    navIcon = <HiChevronLeft className="nav-chevron mt-3 h-6 w-4" style={{ color: iconColor }} />
+  } else {
+    stackDirection = "row-reverse"
+    navIcon = <HiChevronRight className="nav-chevron mt-3 h-6 w-4" style={{ color: iconColor }} />
   }
+
+  return (
+    <Tooltip title={tooltipTitle}>
+      <a href={`${sectionLink.url}`} className={`pointer-events-auto text-gray-600 hover:text-gray-500 opacity-50`}>
+        <div
+          className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[55px] w-[150px] text-sm`}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          <Stack spacing={1} direction={stackDirection as "row" | "col" | "row-reverse" | "col-reverse" | undefined}>
+            {navIcon}
+            <div>
+              {sectionLink.theme && (
+                <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">
+                  {trimString(sectionLink.theme, 21)}
+                </p>
+              )}
+              {sectionLink.course && (
+                <p className="text-slate-600 dark:text-slate-300 text-xs"> {trimString(sectionLink.course, 21)} </p>
+              )}
+              {sectionLink.section && (
+                <p className="text-slate-700 dark:text-slate-400">
+                  {trimString(sectionLink.section, 16)} {sectionLink.tags && `[${sectionLink.tags.join(", ")}]`}
+                </p>
+              )}
+            </div>
+          </Stack>
+        </div>
+      </a>
+    </Tooltip>
+  )
 }

--- a/components/ui/LinkedSection.tsx
+++ b/components/ui/LinkedSection.tsx
@@ -19,7 +19,6 @@ export const LinkedSection = (sectionLink: SectionLink) => {
   let borderColor = "border-grey-700 dark:border-grey-500"
 
   const handleMouseEnter = (e: SyntheticEvent) => {
-    console.log(e)
     e.currentTarget.classList.add("parent-hovered")
   }
 

--- a/components/ui/LinkedSection.tsx
+++ b/components/ui/LinkedSection.tsx
@@ -2,6 +2,7 @@ import { Section } from "lib/material"
 import { HiArrowCircleLeft, HiArrowCircleRight, HiChevronLeft, HiChevronRight } from "react-icons/hi"
 import Stack from "./Stack"
 import React, { SyntheticEvent, useRef } from "react"
+import { Tooltip } from "@mui/material"
 
 export type SectionLink = {
   theme?: String
@@ -11,12 +12,15 @@ export type SectionLink = {
   linkedType: string
   direction: string
   url: string
-  offset: number
 }
 
 export const LinkedSection = (sectionLink: SectionLink) => {
   let iconColor = "grey"
   let borderColor = "border-grey-700 dark:border-grey-500"
+
+  const trimString = (str: String, len: number) => {
+    return str.length > len ? str.substring(0, len - 3) + "..." : str
+  }
 
   const handleMouseEnter = (e: SyntheticEvent) => {
     e.currentTarget.classList.add("parent-hovered")
@@ -37,75 +41,73 @@ export const LinkedSection = (sectionLink: SectionLink) => {
     borderColor = "border-fuchsia-700 dark:border-fuchsia-500"
   }
 
+  const tooltipTitle =
+    (sectionLink.theme ? sectionLink.theme + ": " : "") +
+    (sectionLink.course ? sectionLink.course + " - " : "") +
+    (sectionLink.section ? sectionLink.section : "")
+
   if (sectionLink.direction === "prev") {
     return (
-      <a
-        href={`${sectionLink.url}`}
-        className={`pointer-events-auto absolute bottom-20 left-0 text-gray-600 hover:text-gray-500 opacity-50`}
-        style={{ marginBottom: `${sectionLink.offset}px` }}
-      >
-        <div
-          className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[85px] w-[160px] -ml-2 text-sm`}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-        >
-          <Stack spacing={4} direction="row">
-            <HiChevronLeft className="nav-chevron absolute right-0 bottom-8 h-6 w-6" style={{ color: iconColor }} />
-            <div className="w-[140px]" style={{ marginLeft: "2px" }}>
-              {sectionLink.theme && (
-                <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">
-                  {sectionLink.theme}
-                  {sectionLink.course && ":"}
-                </p>
-              )}
-              {sectionLink.course && <p className="text-slate-600 dark:text-slate-300 text-xs">{sectionLink.course}</p>}
-              {sectionLink.section && (
-                <p className="text-slate-700 dark:text-slate-400">
-                  {sectionLink.section} {sectionLink.tags && `[${sectionLink.tags.join(", ")}]`}
-                </p>
-              )}
-            </div>
-          </Stack>
-        </div>
-      </a>
-    )
-  } else if (sectionLink.direction === "next") {
-    return (
-      <a
-        href={`${sectionLink.url}`}
-        className={`pointer-events-auto absolute bottom-20 right-0 text-gray-600 hover:text-gray-500 opacity-50`}
-        style={{ marginBottom: `${sectionLink.offset}px` }}
-      >
-        <div
-          className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[85px] w-[160px]`}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-          style={{ color: `${iconColor}` }}
-        >
-          <Stack spacing={4} direction="row">
-            <div>
-              <HiChevronRight
-                className="nav-chevron absolute left-0 bottom-8 h-6 w-6"
-                style={{ color: `${iconColor}` }}
-              />
-              <div className="w-[140px] ml-[20px]">
+      <Tooltip title={tooltipTitle}>
+        <a href={`${sectionLink.url}`} className={`pointer-events-auto text-gray-600 hover:text-gray-500 opacity-50`}>
+          <div
+            className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[55px] w-[170px] -ml-2 text-sm`}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            <Stack spacing={4} direction="row">
+              <div style={{ marginLeft: "2px" }}>
                 {sectionLink.theme && (
-                  <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">{sectionLink.theme} :</p>
+                  <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">
+                    {trimString(sectionLink.theme, 21)}
+                  </p>
                 )}
                 {sectionLink.course && (
-                  <p className="text-slate-600 dark:text-slate-300 text-xs">{sectionLink.course}</p>
+                  <p className="text-slate-600 dark:text-slate-300 text-xs"> {trimString(sectionLink.course, 21)} </p>
                 )}
                 {sectionLink.section && (
-                  <p className="text-slate-700 dark:text-slate-400 text-xs">
-                    {sectionLink.section}
-                    {sectionLink.tags && ` [${sectionLink.tags.join(", ")}]`}
+                  <p className="text-slate-700 dark:text-slate-400">
+                    {trimString(sectionLink.section, 16)} {sectionLink.tags && `[${sectionLink.tags.join(", ")}]`}
                   </p>
                 )}
               </div>
-            </div>
-          </Stack>
-        </div>
-      </a>
+
+              <HiChevronLeft className="nav-chevron mt-3 h-6 w-5" style={{ color: iconColor }} />
+            </Stack>
+          </div>
+        </a>
+      </Tooltip>
+    )
+  } else if (sectionLink.direction === "next") {
+    return (
+      <Tooltip title={tooltipTitle}>
+        <a href={`${sectionLink.url}`} className={`pointer-events-auto text-gray-600 hover:text-gray-500 opacity-50`}>
+          <div
+            className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[55px] w-[170px] -ml-2 text-sm`}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            <Stack spacing={4} direction="row">
+              <HiChevronRight className="nav-chevron mt-3 h-6 w-5" style={{ color: iconColor }} />
+              <div className="w-[140px]" style={{ marginLeft: "2px" }}>
+                {sectionLink.theme && (
+                  <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">
+                    {trimString(sectionLink.theme, 21)}
+                  </p>
+                )}
+                {sectionLink.course && (
+                  <p className="text-slate-600 dark:text-slate-300 text-xs">{trimString(sectionLink.course, 21)}</p>
+                )}
+                {sectionLink.section && (
+                  <p className="text-slate-700 dark:text-slate-400">
+                    {trimString(sectionLink.section, 16)} {sectionLink.tags && `[${sectionLink.tags.join(", ")}]`}
+                  </p>
+                )}
+              </div>
+            </Stack>
+          </div>
+        </a>
+      </Tooltip>
     )
   }
 }

--- a/components/ui/LinkedSection.tsx
+++ b/components/ui/LinkedSection.tsx
@@ -1,0 +1,113 @@
+
+import { Section } from "lib/material"
+import { HiArrowCircleLeft, HiArrowCircleRight, HiChevronLeft, HiChevronRight } from "react-icons/hi"
+import Stack from "./Stack"
+import React, { SyntheticEvent, useRef } from "react"
+
+export type SectionLink = {
+  theme?: String
+  course?: String
+  section?: String
+  tags?: String[]
+  linkedType: string
+  direction: string
+  url: string
+  offset: number
+}
+
+export const LinkedSection = (sectionLink: SectionLink) => {
+  let iconColor = "grey"
+  let borderColor = "border-grey-700 dark:border-grey-500"
+
+  const handleMouseEnter = (e: SyntheticEvent) => {
+    console.log(e)
+    e.currentTarget.classList.add("parent-hovered")
+  }
+
+  const handleMouseLeave = (e: SyntheticEvent) => {
+    e.currentTarget.classList.remove("parent-hovered")
+  }
+
+  if (sectionLink.linkedType === "event") {
+    iconColor = "#14b8a6"
+    borderColor = "border-teal-700 dark:border-teal-500"
+  } else if (sectionLink.linkedType === "internal") {
+    iconColor = "#a855f7"
+    borderColor = "border-purple-700 dark:border-purple-500"
+  } else {
+    iconColor = "#d946ef"
+    borderColor = "border-fuchsia-700 dark:border-fuchsia-500"
+  }
+
+  if (sectionLink.direction === "prev") {
+    return (
+      <a
+        href={`${sectionLink.url}`}
+        className={`pointer-events-auto absolute bottom-20 left-0 text-gray-600 hover:text-gray-500 opacity-50`}
+        style={{ marginBottom: `${sectionLink.offset}px` }}
+      >
+        <div
+          className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[85px] w-[160px] -ml-2 text-sm`}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          <Stack spacing={4} direction="row">
+            <HiChevronLeft className="nav-chevron absolute right-0 bottom-8 h-6 w-6" style={{ color: iconColor }} />
+            <div className="w-[140px]" style={{ marginLeft: "2px" }}>
+              {sectionLink.theme && (
+                <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">
+                  {sectionLink.theme}
+                  {sectionLink.course && ":"}
+                </p>
+              )}
+              {sectionLink.course && <p className="text-slate-600 dark:text-slate-300 text-xs">{sectionLink.course}</p>}
+              {sectionLink.section && (
+                <p className="text-slate-700 dark:text-slate-400">
+                  {sectionLink.section} {sectionLink.tags && `[${sectionLink.tags.join(", ")}]`}
+                </p>
+              )}
+            </div>
+          </Stack>
+        </div>
+      </a>
+    )
+  } else if (sectionLink.direction === "next") {
+    return (
+      <a
+        href={`${sectionLink.url}`}
+        className={`pointer-events-auto absolute bottom-20 right-0 text-gray-600 hover:text-gray-500 opacity-50`}
+        style={{ marginBottom: `${sectionLink.offset}px` }}
+      >
+        <div
+          className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[85px] w-[160px]`}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          style={{ color: `${iconColor}` }}
+        >
+          <Stack spacing={4} direction="row">
+            <div>
+              <HiChevronRight
+                className="nav-chevron absolute left-0 bottom-8 h-6 w-6"
+                style={{ color: `${iconColor}` }}
+              />
+              <div className="w-[140px] ml-[20px]">
+                {sectionLink.theme && (
+                  <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">{sectionLink.theme} :</p>
+                )}
+                {sectionLink.course && (
+                  <p className="text-slate-600 dark:text-slate-300 text-xs">{sectionLink.course}</p>
+                )}
+                {sectionLink.section && (
+                  <p className="text-slate-700 dark:text-slate-400 text-xs">
+                    {sectionLink.section}
+                    {sectionLink.tags && ` [${sectionLink.tags.join(", ")}]`}
+                  </p>
+                )}
+              </div>
+            </div>
+          </Stack>
+        </div>
+      </a>
+    )
+  }
+}

--- a/lib/findSectionLinks.ts
+++ b/lib/findSectionLinks.ts
@@ -44,9 +44,6 @@ export const findLinks = (
   // check if this section is part of the active event
   let isInEvent = false
   let sectionLinks: SectionLink[] = []
-  // we stack the linked section components on top of each other
-  let leftOffset = 90
-  let rightOffset = 90
 
   if (activeEvent) {
     for (const group of activeEvent.EventGroup) {
@@ -68,7 +65,6 @@ export const findLinks = (
               linkedType: "event",
               direction: "prev",
               url: url,
-              offset: 0,
               section: sectionLink?.name,
               course: courseLink?.name,
               theme: themeLink?.name,
@@ -87,7 +83,6 @@ export const findLinks = (
               linkedType: "event",
               direction: "next",
               url: url,
-              offset: 0,
               section: sectionLink?.name,
               course: courseLink?.name,
               theme: themeLink?.name,
@@ -110,13 +105,11 @@ export const findLinks = (
       linkedType: courseLink?.id == course?.id ? "internal" : "external",
       direction: "prev",
       url: url,
-      offset: leftOffset,
       section: sectionLink?.name,
       course: courseLink?.name,
       theme: themeLink?.name,
       tags: sectionLink?.tags,
     } as SectionLink)
-    leftOffset += 90
   })
   if (section) {
     const parents = findChildren()
@@ -129,13 +122,11 @@ export const findLinks = (
           linkedType: courseLink?.id == course?.id ? "internal" : "external",
           direction: "next",
           url: url,
-          offset: rightOffset,
           section: sectionLink?.name,
           course: courseLink?.name,
           theme: themeLink?.name,
           tags: sectionLink?.tags,
         } as SectionLink)
-        rightOffset += 90
       }
     }
   }

--- a/lib/findSectionLinks.ts
+++ b/lib/findSectionLinks.ts
@@ -26,7 +26,6 @@ export const findLinks = (
             c.sections.map((sec) => {
               sec.dependsOn.map((dep) => {
                 if (dep == pageLabelShort) {
-                  console.log(sec)
                   children.push([th.repo, th.id, c.id, sec.id].join("."))
                 }
               })
@@ -38,7 +37,6 @@ export const findLinks = (
     if (children.length == 0) {
       return undefined
     }
-    console.log("parents", children)
     return children
   }
   // check if this section is part of the active event

--- a/lib/findSectionLinks.ts
+++ b/lib/findSectionLinks.ts
@@ -1,0 +1,143 @@
+import { SectionLink, LinkedSection } from "components/ui/LinkedSection"
+import { getExcludes } from "lib/material"
+import { Material, Theme, Course, Section } from "./material"
+import { sectionSplit } from "./material"
+import { EventFull } from "lib/types"
+
+export const findLinks = (
+  material: Material,
+  theme?: Theme,
+  course?: Course,
+  section?: Section,
+  activeEvent?: EventFull | undefined
+): SectionLink[] => {
+  const pageLabel = `${theme?.repo}.${theme?.id}.${course?.id}${section ? `.${section.id}` : ""}`
+
+  const findChildren = (): String[] | undefined => {
+    const children: string[] = []
+    const pageLabelShort = pageLabel.split(".").slice(1, pageLabel.split(".").length).join(".")
+    material.themes.map((th) => {
+      if (th.courses != undefined) {
+        th.courses.map((c) => {
+          if (c.dependsOn.includes(pageLabelShort)) {
+            children.push([th.repo, th.id, c.id].join("."))
+          }
+          if (c.sections != undefined) {
+            c.sections.map((sec) => {
+              sec.dependsOn.map((dep) => {
+                if (dep == pageLabelShort) {
+                  console.log(sec)
+                  children.push([th.repo, th.id, c.id, sec.id].join("."))
+                }
+              })
+            })
+          }
+        })
+      }
+    })
+    if (children.length == 0) {
+      return undefined
+    }
+    console.log("parents", children)
+    return children
+  }
+  // check if this section is part of the active event
+  let isInEvent = false
+  let sectionLinks: SectionLink[] = []
+  // we stack the linked section components on top of each other
+  let leftOffset = 90
+  let rightOffset = 90
+
+  if (activeEvent) {
+    for (const group of activeEvent.EventGroup) {
+      let orderedEvents = [...group.EventItem]
+      orderedEvents.sort((a, b) => a.order - b.order)
+      for (let i = 0; i < group.EventItem.length; i++) {
+        const item = orderedEvents[i]
+        if (item.section == pageLabel) {
+          isInEvent = true
+          if (i > 0) {
+            const prevItem = orderedEvents[i - 1]
+            const {
+              theme: themeLink,
+              course: courseLink,
+              section: sectionLink,
+              url,
+            } = sectionSplit(`${prevItem.section}`, material)
+            sectionLinks.push({
+              linkedType: "event",
+              direction: "prev",
+              url: url,
+              offset: 0,
+              section: sectionLink?.name,
+              course: courseLink?.name,
+              theme: themeLink?.name,
+              tags: sectionLink?.tags,
+            } as SectionLink)
+          }
+          if (i < group.EventItem.length - 1) {
+            const nextItem = orderedEvents[i + 1]
+            const {
+              theme: themeLink,
+              course: courseLink,
+              section: sectionLink,
+              url,
+            } = sectionSplit(`${nextItem.section}`, material)
+            sectionLinks.push({
+              linkedType: "event",
+              direction: "next",
+              url: url,
+              offset: 0,
+              section: sectionLink?.name,
+              course: courseLink?.name,
+              theme: themeLink?.name,
+              tags: sectionLink?.tags,
+            } as SectionLink)
+          }
+        }
+      }
+    }
+  }
+  // We also can generate links for all dependents
+  section?.dependsOn.map((dep) => {
+    const {
+      theme: themeLink,
+      course: courseLink,
+      section: sectionLink,
+      url,
+    } = sectionSplit(`${theme?.repo}.${dep}`, material)
+    sectionLinks.push({
+      linkedType: courseLink?.id == course?.id ? "internal" : "external",
+      direction: "prev",
+      url: url,
+      offset: leftOffset,
+      section: sectionLink?.name,
+      course: courseLink?.name,
+      theme: themeLink?.name,
+      tags: sectionLink?.tags,
+    } as SectionLink)
+    leftOffset += 90
+  })
+  if (section) {
+    const parents = findChildren()
+    if (parents) {
+      for (const parent of parents) {
+        const { theme: themeLink, course: courseLink, section: sectionLink, url } = sectionSplit(parent, material)
+
+        sectionLinks.push({
+          // if the section shares the same course we set linkedType to internal, else external
+          linkedType: courseLink?.id == course?.id ? "internal" : "external",
+          direction: "next",
+          url: url,
+          offset: rightOffset,
+          section: sectionLink?.name,
+          course: courseLink?.name,
+          theme: themeLink?.name,
+          tags: sectionLink?.tags,
+        } as SectionLink)
+        rightOffset += 90
+      }
+    }
+  }
+  return sectionLinks
+}

--- a/lib/hooks/useWindowSize.ts
+++ b/lib/hooks/useWindowSize.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react"
+
+interface WindowSize {
+  width?: number | undefined
+  height?: number | undefined
+}
+
+// this hook is used to get the window size
+// can be used to remove or change components based on a min size (i.e. exclude mobiles)
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: undefined,
+    height: undefined,
+  })
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const handleResize = () => {
+        setWindowSize({
+          width: window.innerWidth,
+          height: window.innerHeight,
+        })
+      }
+
+      window.addEventListener("resize", handleResize)
+      handleResize()
+      return () => window.removeEventListener("resize", handleResize)
+    }
+  }, [])
+  return windowSize
+}
+
+export default useWindowSize

--- a/lib/material.ts
+++ b/lib/material.ts
@@ -60,6 +60,9 @@ export type Material = {
   markdown: string
   themes: Theme[]
   type: string
+  themeNames?: {}
+  courseNames?: {}
+  sectionNames?: {}
 }
 
 export const sectionSplit = (
@@ -105,7 +108,7 @@ export const eventItemSplit = (
   return sectionSplit(eventItem.section, material)
 }
 
-export function remove_markdown(material: Material, except: Material | Theme | Course | Section | undefined) {
+export function removeMarkdown(material: Material, except: Material | Theme | Course | Section | undefined) {
   if (except === undefined || except.type !== "Material") {
     material.markdown = ""
   }

--- a/pages/event/[eventId].tsx
+++ b/pages/event/[eventId].tsx
@@ -1,6 +1,6 @@
 import type { NextPage, GetStaticProps, GetStaticPaths } from "next"
 import prisma from "lib/prisma"
-import { getMaterial, Theme, Material, remove_markdown } from "lib/material"
+import { getMaterial, Theme, Material, removeMarkdown } from "lib/material"
 import Layout from "components/Layout"
 import { makeSerializable } from "lib/utils"
 import Content from "components/content/Content"
@@ -235,7 +235,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
 
   let material = await getMaterial()
 
-  remove_markdown(material, undefined)
+  removeMarkdown(material, undefined)
 
   return {
     props: makeSerializable({ event, material, pageInfo }),

--- a/pages/event/[eventId]/[eventGroupId].tsx
+++ b/pages/event/[eventId]/[eventGroupId].tsx
@@ -1,6 +1,6 @@
 import type { NextPage, GetStaticProps, GetStaticPaths } from "next"
 import prisma from "lib/prisma"
-import { getMaterial, Theme, Material, remove_markdown, eventItemSplit } from "lib/material"
+import { getMaterial, Theme, Material, removeMarkdown, eventItemSplit } from "lib/material"
 import Layout from "components/Layout"
 import { makeSerializable } from "lib/utils"
 import Content from "components/content/Content"
@@ -244,7 +244,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
 
   let material = await getMaterial()
 
-  remove_markdown(material, undefined)
+  removeMarkdown(material, undefined)
 
   return {
     props: makeSerializable({ event, material, eventGroupId, pageInfo }),

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import prisma from "lib/prisma"
 import Layout from "components/Layout"
 import { makeSerializable } from "lib/utils"
-import { Material, getMaterial, remove_markdown } from "lib/material"
+import { Material, getMaterial, removeMarkdown } from "lib/material"
 import { basePath } from "lib/basePath"
 import { Event } from "lib/types"
 import { Button, Card } from "flowbite-react"
@@ -67,7 +67,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
       return []
     })
   let material = await getMaterial()
-  remove_markdown(material, material)
+  removeMarkdown(material, material)
 
   return {
     props: {

--- a/pages/material/[repoId]/[themeId].tsx
+++ b/pages/material/[repoId]/[themeId].tsx
@@ -1,6 +1,6 @@
 import type { NextPage, GetStaticProps, GetStaticPaths } from "next"
 import prisma from "lib/prisma"
-import { getMaterial, Theme, Material, remove_markdown, getExcludes, Excludes } from "lib/material"
+import { getMaterial, Theme, Material, removeMarkdown, getExcludes, Excludes } from "lib/material"
 import Layout from "components/Layout"
 import { makeSerializable } from "lib/utils"
 import Content from "components/content/Content"
@@ -57,7 +57,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     return { notFound: true }
   }
 
-  remove_markdown(material, theme)
+  removeMarkdown(material, theme)
 
   return {
     props: makeSerializable({ material, theme, events, pageInfo, excludes }),

--- a/pages/material/[repoId]/[themeId]/[courseId].tsx
+++ b/pages/material/[repoId]/[themeId]/[courseId].tsx
@@ -1,9 +1,8 @@
 import type { NextPage, GetStaticProps, GetStaticPaths } from "next"
 import prisma from "lib/prisma"
-import { getMaterial, Course, Theme, Material, remove_markdown } from "lib/material"
+import { getMaterial, Course, Theme, Material, removeMarkdown } from "lib/material"
 import Layout from "components/Layout"
 import { makeSerializable } from "lib/utils"
-import { remove } from "cypress/types/lodash"
 import Content from "components/content/Content"
 import NavDiagram from "components/NavDiagram"
 import Title from "components/ui/Title"
@@ -76,7 +75,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
   if (!course) {
     return { notFound: true }
   }
-  remove_markdown(material, course)
+  removeMarkdown(material, course)
   return { props: makeSerializable({ theme, course, material, events, pageInfo }) }
 }
 

--- a/pages/material/[repoId]/[themeId]/[courseId]/[sectionId].tsx
+++ b/pages/material/[repoId]/[themeId]/[courseId]/[sectionId].tsx
@@ -1,6 +1,6 @@
 import type { NextPage, GetStaticProps, GetStaticPaths } from "next"
 import prisma from "lib/prisma"
-import { getMaterial, Course, Theme, Material, Section, remove_markdown, getRepoUrl } from "lib/material"
+import { getMaterial, Course, Theme, Material, Section, removeMarkdown, getRepoUrl } from "lib/material"
 import Layout from "components/Layout"
 import { makeSerializable } from "lib/utils"
 import Content from "components/content/Content"
@@ -94,7 +94,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
   if (!section) {
     return { notFound: true }
   }
-  remove_markdown(material, section)
+  removeMarkdown(material, section)
   return { props: makeSerializable({ theme, course, section, events, material, pageInfo, repoUrl }) }
 }
 

--- a/pages/material/index.tsx
+++ b/pages/material/index.tsx
@@ -2,7 +2,7 @@ import type { NextPage, GetStaticProps } from "next"
 import prisma from "lib/prisma"
 import Layout from "components/Layout"
 import { makeSerializable } from "lib/utils"
-import { Material, getMaterial, remove_markdown } from "lib/material"
+import { Material, getMaterial, removeMarkdown } from "lib/material"
 import Content from "components/content/Content"
 import NavDiagram from "components/NavDiagram"
 import { EventFull as Event, EventFull } from "lib/types"
@@ -51,7 +51,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
       return []
     })
   let material = await getMaterial()
-  remove_markdown(material, material)
+  removeMarkdown(material, material)
 
   return {
     props: {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -46,3 +46,15 @@ ul:has(li.mdli) {
   list-style-type: disc !important;
   list-style-position: outside;
 }
+
+:root {
+  --icon-stroke-width: 1px;
+}
+
+.parent-hovered {
+  --icon-stroke-width: 2px;
+}
+
+.nav-chevron {
+  stroke-width: var(--icon-stroke-width);
+}


### PR DESCRIPTION
If another course section has a dependsOn on the current section or if the current section as a dependsOn a parent section then this generates a navlink to these.

The navlinks come in 3 colours for activeevent (those defined by the event) internal dependsOn (from the same course) and external, which is usually when a course depends on prior course or if a course is a logical follow on from the current course.

![image](https://github.com/OxfordRSE/gutenberg/assets/60351846/1b0e2924-ff6a-4b5e-8d68-b01dadef18b9)

There is also a highlight on mouse over (which is why one looks different)


