### PR TITLE
Mouse over navigation in navbar

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -6,7 +6,7 @@ import { useState } from "react"
 import React, { ReactNode } from "react"
 import Footer from "./Footer"
 import Header from "./Header"
-import { Material } from "lib/material"
+import { Material, Excludes } from "lib/material"
 import Overlay from "./Overlay"
 import Navbar from "./Navbar"
 import { useSidebarOpen } from "lib/hooks/useSidebarOpen"
@@ -22,9 +22,10 @@ type Props = {
   children: ReactNode
   pageInfo?: PageTemplate
   repoUrl?: string
+  excludes?: Excludes
 }
 
-const Layout: React.FC<Props> = ({ material, theme, course, section, children, pageInfo, repoUrl }) => {
+const Layout: React.FC<Props> = ({ material, theme, course, section, children, pageInfo, repoUrl, excludes }) => {
   const [activeEvent, setActiveEvent] = useActiveEvent()
   const router = useRouter()
   const { data: session } = useSession()
@@ -76,6 +77,7 @@ const Layout: React.FC<Props> = ({ material, theme, course, section, children, p
             showAttribution={showAttribution}
             setShowAttribution={setShowAttribution}
             repoUrl={repoUrl}
+            excludes={excludes}
           />
           <Overlay
             material={material}

--- a/components/NavDiagram.tsx
+++ b/components/NavDiagram.tsx
@@ -419,7 +419,10 @@ const NavDiagram: React.FC<NavDiagramProps> = ({ material, theme, course, exclud
       : { aspectRatio: "16 / 9", width: "100%" }
   return (
     <div className="flex justify-center mb-5">
-      <div style={style} className="border border-gray-200 rounded-lg shadow-md dark:border-gray-700">
+      <div
+        style={style}
+        className="border border-gray-200 rounded-lg shadow-md dark:border-gray-700 bg-white dark:bg-gray-800"
+      >
         <ReactFlow
           nodes={nodes}
           edges={edges}

--- a/components/NavDiagram.tsx
+++ b/components/NavDiagram.tsx
@@ -355,11 +355,12 @@ interface NavDiagramProps {
   theme?: Theme
   course?: Course
   excludes?: Excludes
+  style?: React.CSSProperties
 }
 
 const blankExcludes: Excludes = { themes: [], courses: [], sections: [] }
 
-const NavDiagram: React.FC<NavDiagramProps> = ({ material, theme, course, excludes }) => {
+const NavDiagram: React.FC<NavDiagramProps> = ({ material, theme, course, excludes, style }) => {
   const defaultNodes: Node[] = []
   const [nodes, setNodes] = useState(defaultNodes)
   const onNodesChange = useCallback((changes: NodeChange[]) => {
@@ -412,11 +413,13 @@ const NavDiagram: React.FC<NavDiagramProps> = ({ material, theme, course, exclud
   if (!nodes) {
     return <div>Generating diagram...</div>
   }
-  const style = course
-    ? { aspectRatio: "12 / 9", width: "50%" }
-    : theme
-      ? { aspectRatio: "14 / 9", width: "70%" }
-      : { aspectRatio: "16 / 9", width: "100%" }
+  if (!style) {
+    style = course
+      ? { aspectRatio: "12 / 9", width: "50%" }
+      : theme
+        ? { aspectRatio: "14 / 9", width: "70%" }
+        : { aspectRatio: "16 / 9", width: "100%" }
+  }
   return (
     <div className="flex justify-center mb-5">
       <div

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -10,6 +10,7 @@ import { searchQueryState } from "components/SearchDialog"
 import { useRecoilState } from "recoil"
 import { enableSearch } from "lib/search/enableSearch"
 import NavDiagramPopover from "./dialogs/navDiagramPop"
+import ThemeCardsPopover from "./dialogs/themeCardPop"
 
 interface Props {
   material: Material
@@ -42,8 +43,11 @@ const Navbar: React.FC<Props> = ({
   const [showNavDiagram, setShowNavDiagram] = useState(false)
   const [isPopoverHovered, setIsPopoverHovered] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
+  const [itemHovered, setItemHovered] = useState("")
   const { data: session } = useSession()
-  const ref = useRef<HTMLLIElement>(null)
+  const ref1 = useRef<HTMLLIElement>(null)
+  const ref2 = useRef<HTMLLIElement>(null)
+  const ref3 = useRef<HTMLLIElement>(null)
   let enterTimer: NodeJS.Timeout
   let leaveTimer: NodeJS.Timeout
 
@@ -72,24 +76,24 @@ const Navbar: React.FC<Props> = ({
       enterTimer = setTimeout(() => {
         setShowNavDiagram(true)
       }, 500)
-    }
-
-    return () => {
-      clearTimeout(enterTimer)
-      clearTimeout(leaveTimer)
-      setShowNavDiagram(false)
+    } else {
+      leaveTimer = setTimeout(() => {
+        clearTimeout(enterTimer)
+        clearTimeout(leaveTimer)
+        setShowNavDiagram(false)
+      }, 500)
     }
   }, [isHovered, isPopoverHovered])
 
-  const handleIsHovered = () => {
+  const handleIsHovered = (hovered: string) => {
     clearTimeout(leaveTimer)
+    setItemHovered(hovered)
     setIsHovered(true)
   }
 
   const handleIsNotHovered = () => {
-    leaveTimer = setTimeout(() => {
-      setIsHovered(false)
-    }, 500)
+    clearTimeout(enterTimer)
+    setIsHovered(false)
   }
 
   const handlePopoverHovered = () => {
@@ -98,9 +102,8 @@ const Navbar: React.FC<Props> = ({
   }
 
   const handlePopoverNotHovered = () => {
-    leaveTimer = setTimeout(() => {
-      setIsPopoverHovered(false)
-    }, 500)
+    clearTimeout(enterTimer)
+    setIsPopoverHovered(false)
   }
 
   return (
@@ -130,7 +133,12 @@ const Navbar: React.FC<Props> = ({
           </Link>
         </li>
         {theme && (
-          <li>
+          <li
+            ref={ref1}
+            aria-current="page"
+            onMouseEnter={() => handleIsHovered("theme")}
+            onMouseLeave={handleIsNotHovered}
+          >
             <div className="flex items-center">
               <svg
                 className="w-6 h-6 text-gray-400"
@@ -139,6 +147,8 @@ const Navbar: React.FC<Props> = ({
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
+                  className={showNavDiagram && itemHovered === "theme" ? "expanded" : "collapsed"}
+                  style={{ transformOrigin: "50% 50%" }}
                   fill-rule="evenodd"
                   d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
                   clip-rule="evenodd"
@@ -150,11 +160,25 @@ const Navbar: React.FC<Props> = ({
               >
                 Material
               </Link>
+              {showNavDiagram && itemHovered === "theme" && (
+                <ThemeCardsPopover
+                  material={material}
+                  excludes={excludes}
+                  onMouseEnter={handlePopoverHovered}
+                  onMouseLeave={handlePopoverNotHovered}
+                  target={ref1?.current || undefined}
+                />
+              )}
             </div>
           </li>
         )}
         {theme && (
-          <li>
+          <li
+            ref={ref2}
+            aria-current="page"
+            onMouseEnter={() => handleIsHovered("course")}
+            onMouseLeave={handleIsNotHovered}
+          >
             <div className="flex items-center">
               <svg
                 className="w-6 h-6 text-gray-400"
@@ -163,6 +187,8 @@ const Navbar: React.FC<Props> = ({
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
+                  className={showNavDiagram && itemHovered === "course" ? "expanded" : "collapsed"}
+                  style={{ transformOrigin: "50% 50%" }}
                   fill-rule="evenodd"
                   d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
                   clip-rule="evenodd"
@@ -174,11 +200,26 @@ const Navbar: React.FC<Props> = ({
               >
                 {theme.name}
               </Link>
+              {showNavDiagram && itemHovered === "course" && (
+                <NavDiagramPopover
+                  material={material}
+                  theme={theme}
+                  excludes={excludes}
+                  target={ref2?.current || undefined}
+                  onMouseEnter={handlePopoverHovered}
+                  onMouseLeave={handlePopoverNotHovered}
+                />
+              )}
             </div>
           </li>
         )}{" "}
         {theme && course && (
-          <li ref={ref} aria-current="page" onMouseEnter={handleIsHovered} onMouseLeave={handleIsNotHovered}>
+          <li
+            ref={ref3}
+            aria-current="page"
+            onMouseEnter={() => handleIsHovered("section")}
+            onMouseLeave={handleIsNotHovered}
+          >
             <div className="flex items-center">
               <svg
                 className="w-6 h-6 text-gray-400"
@@ -187,6 +228,8 @@ const Navbar: React.FC<Props> = ({
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
+                  className={showNavDiagram && itemHovered === "section" ? "expanded" : "collapsed"}
+                  style={{ transformOrigin: "50% 50%" }}
                   fill-rule="evenodd"
                   d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
                   clip-rule="evenodd"
@@ -198,12 +241,13 @@ const Navbar: React.FC<Props> = ({
               >
                 {course.name}
               </Link>
-              {showNavDiagram && (
+              {showNavDiagram && itemHovered === "section" && (
                 <NavDiagramPopover
                   material={material}
                   theme={theme}
+                  course={course}
                   excludes={excludes}
-                  target={ref?.current || undefined}
+                  target={ref3?.current || undefined}
                   onMouseEnter={handlePopoverHovered}
                   onMouseLeave={handlePopoverNotHovered}
                 />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import { Avatar, Dropdown, Tooltip } from "flowbite-react"
-import { Course, Material, Section, Theme } from "lib/material"
+import { Course, Material, Section, Theme, getExcludes, Excludes } from "lib/material"
 import { Event, EventFull } from "lib/types"
 import { signIn, signOut, useSession } from "next-auth/react"
 import Link from "next/link"
@@ -10,7 +10,6 @@ import { searchQueryState } from "components/SearchDialog"
 import { useRecoilState } from "recoil"
 import { enableSearch } from "lib/search/enableSearch"
 import NavDiagramPopover from "./dialogs/navDiagramPop"
-import { use } from "chai"
 
 interface Props {
   material: Material
@@ -23,6 +22,7 @@ interface Props {
   sidebarOpen: boolean
   showAttribution: boolean
   repoUrl?: string
+  excludes?: Excludes
 }
 
 const Navbar: React.FC<Props> = ({
@@ -36,6 +36,7 @@ const Navbar: React.FC<Props> = ({
   sidebarOpen,
   showAttribution,
   repoUrl,
+  excludes,
 }) => {
   const [showSearch, setShowSearch] = useRecoilState(searchQueryState)
   const [showNavDiagram, setShowNavDiagram] = useState(false)
@@ -199,6 +200,9 @@ const Navbar: React.FC<Props> = ({
               </Link>
               {showNavDiagram && (
                 <NavDiagramPopover
+                  material={material}
+                  theme={theme}
+                  excludes={excludes}
                   target={ref?.current || undefined}
                   onMouseEnter={handlePopoverHovered}
                   onMouseLeave={handlePopoverNotHovered}

--- a/components/ThemeCards.tsx
+++ b/components/ThemeCards.tsx
@@ -1,0 +1,25 @@
+import { Material, Excludes } from "lib/material"
+import { basePath } from "lib/basePath"
+import { Card } from "flowbite-react"
+
+interface Props {
+  material: Material
+  excludes?: Excludes
+  includeSummary?: boolean
+}
+
+const ThemeCards = ({ material, excludes, includeSummary = true }: Props) => {
+  const textSize = includeSummary ? "text-2xl" : "text-md"
+  const themeCards = material?.themes
+    .filter((theme) => !excludes || !excludes.themes.includes(theme.id))
+    .map((theme) => (
+      <Card key={theme.repo + theme.id} href={`${basePath}/material/${theme.repo}/${theme.id}`} className="w-90%">
+        <h2 className={`mb-2 ${textSize} font-bold tracking-tight text-gray-900 dark:text-white`}>{theme.name}</h2>
+        {includeSummary && <p>{theme.summary}</p>}
+      </Card>
+    ))
+
+  return <div className="px-2 mt-2 mb-2 grid grid-cols-1 gap-4 items-start">{themeCards}</div>
+}
+
+export default ThemeCards

--- a/components/dialogs/navDiagramPop.tsx
+++ b/components/dialogs/navDiagramPop.tsx
@@ -1,5 +1,7 @@
-import React, { FunctionComponent, useEffect, useState } from "react"
+import NavDiagram from "components/NavDiagram"
+import React, { useEffect, useState } from "react"
 import { createPortal } from "react-dom"
+import { Material, Theme, Excludes } from "lib/material"
 
 interface PortalProps {
   children: React.ReactNode
@@ -9,11 +11,22 @@ const Portal = ({ children }: PortalProps) => {
   return createPortal(children, document.body)
 }
 
-const NavDiagramPopover = ({ target, onMouseEnter, onMouseLeave }: { target?: HTMLElement | null, onMouseEnter: () => void, onMouseLeave: () => void }) => {
+const NavDiagramPopover = ({
+  material,
+  theme,
+  excludes,
+  target,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  material: Material
+  theme: Theme
+  excludes: Excludes
+  target?: HTMLElement | null
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}) => {
   const [style, setStyle] = useState({ top: 0, left: 0 })
-  const [timeoutId, setTimeoutId] = useState<number | undefined>(undefined)
-
-  console.log("ppopop", target)
 
   useEffect(() => {
     if (target) {
@@ -33,11 +46,17 @@ const NavDiagramPopover = ({ target, onMouseEnter, onMouseLeave }: { target?: HT
     <Portal>
       <div
         data-cy="nav-diagram-popover"
-        style={{ left: style.left, top: style.top, position: "absolute" }}
+        style={{
+          left: style.left,
+          top: style.top,
+          position: "absolute",
+          height: "512px",
+          width: "1024px",
+        }}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
-        asda;dflkasfp;oas ~asd;lamfsaf Asdal'[;;msfaf asdafgsafxzgzxgxgxasdzxf asdafszxf
+        <NavDiagram material={material} theme={theme} excludes={excludes} />
       </div>
     </Portal>
   )

--- a/components/dialogs/navDiagramPop.tsx
+++ b/components/dialogs/navDiagramPop.tsx
@@ -1,0 +1,46 @@
+import React, { FunctionComponent, useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+
+interface PortalProps {
+  children: React.ReactNode
+}
+
+const Portal = ({ children }: PortalProps) => {
+  return createPortal(children, document.body)
+}
+
+const NavDiagramPopover = ({ target, onMouseEnter, onMouseLeave }: { target?: HTMLElement | null, onMouseEnter: () => void, onMouseLeave: () => void }) => {
+  const [style, setStyle] = useState({ top: 0, left: 0 })
+  const [timeoutId, setTimeoutId] = useState<number | undefined>(undefined)
+
+  console.log("ppopop", target)
+
+  useEffect(() => {
+    if (target) {
+      const rect = target.getBoundingClientRect()
+      const top = rect.top + rect.height // Position below the target element
+      const left = rect.left // Align with the left edge of the target element
+      setStyle({
+        top: top + window.scrollY, // Adjust for page scroll
+        left: left + window.scrollX, // Adjust for page scroll
+      })
+    }
+  }, [target])
+
+  console.log("style", style)
+
+  return (
+    <Portal>
+      <div
+        data-cy="nav-diagram-popover"
+        style={{ left: style.left, top: style.top, position: "absolute" }}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        asda;dflkasfp;oas ~asd;lamfsaf Asdal'[;;msfaf asdafgsafxzgzxgxgxasdzxf asdafszxf
+      </div>
+    </Portal>
+  )
+}
+
+export default NavDiagramPopover

--- a/components/dialogs/themeCardPop.tsx
+++ b/components/dialogs/themeCardPop.tsx
@@ -1,17 +1,7 @@
-import NavDiagram from "components/NavDiagram"
-import React, { useEffect, useState } from "react"
+import ThemeCards from "components/ThemeCards"
+import react, { useEffect, useState } from "react"
 import { createPortal } from "react-dom"
-import { Material, Theme, Course, Excludes } from "lib/material"
-
-interface Props {
-  material: Material
-  theme: Theme
-  course?: Course
-  excludes?: Excludes
-  target?: HTMLElement | null
-  onMouseEnter: () => void
-  onMouseLeave: () => void
-}
+import { Material, Excludes } from "lib/material"
 
 interface PortalProps {
   children: React.ReactNode
@@ -21,19 +11,28 @@ const Portal = ({ children }: PortalProps) => {
   return createPortal(children, document.body)
 }
 
-const NavDiagramPopover = ({ material, theme, course, excludes, target, onMouseEnter, onMouseLeave }: Props) => {
+interface Props {
+  material: Material
+  excludes?: Excludes
+  target?: HTMLElement | null
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}
+
+const ThemeCardsPopover = ({ material, excludes, target, onMouseEnter, onMouseLeave }: Props) => {
   const [style, setStyle] = useState({ top: 0, left: 0 })
   // delay the render ever so slightly to stop flickering
   useEffect(() => {
     const timeout = setTimeout(() => {
       // remove the hidden class from our div
-      const popover = document.querySelector("[data-cy=nav-diagram-popover]")
+      const popover = document.querySelector("[data-cy=theme-cards-popover]")
       if (popover) {
         popover.classList.remove("hidden")
       }
     }, 50)
     return () => clearTimeout(timeout)
   }, [])
+
   useEffect(() => {
     if (target) {
       const rect = target.getBoundingClientRect()
@@ -49,28 +48,21 @@ const NavDiagramPopover = ({ material, theme, course, excludes, target, onMouseE
   return (
     <Portal>
       <div
-        className="hidden"
-        data-cy="nav-diagram-popover"
+        className="hidden border border-gray-200 shadow-md dark:border-gray-700 bg-white dark:bg-gray-800"
+        data-cy="theme-cards-popover"
         style={{
           left: style.left,
           top: style.top,
           position: "absolute",
-          height: "512px",
-          width: "600px",
+          zIndex: 1000,
         }}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
-        <NavDiagram
-          material={material}
-          theme={theme}
-          course={course}
-          excludes={excludes}
-          style={{ aspectRatio: "12 / 9", width: "100%" }}
-        />
+        <ThemeCards material={material} excludes={excludes} includeSummary={false} />
       </div>
     </Portal>
   )
 }
 
-export default NavDiagramPopover
+export default ThemeCardsPopover

--- a/pages/material/[repoId]/[themeId].tsx
+++ b/pages/material/[repoId]/[themeId].tsx
@@ -50,7 +50,6 @@ export const getStaticProps: GetStaticProps = async (context) => {
   if (!themeId || Array.isArray(themeId)) {
     return { notFound: true }
   }
-  console.log(process.env.NEXT_PUBLIC_EXCLUDE_THEMES)
   const excludes = getExcludes(repoId as string)
   const theme = material.themes.find((t) => t.id === themeId && t.repo === repoId)
   if (!theme) {

--- a/pages/material/[repoId]/[themeId]/[courseId]/[sectionId].tsx
+++ b/pages/material/[repoId]/[themeId]/[courseId]/[sectionId].tsx
@@ -1,12 +1,23 @@
 import type { NextPage, GetStaticProps, GetStaticPaths } from "next"
 import prisma from "lib/prisma"
-import { getMaterial, Course, Theme, Material, Section, remove_markdown, getRepoUrl } from "lib/material"
+import {
+  getMaterial,
+  Course,
+  Theme,
+  Material,
+  Section,
+  remove_markdown,
+  getRepoUrl,
+  getExcludes,
+  Excludes,
+} from "lib/material"
 import Layout from "components/Layout"
 import { makeSerializable } from "lib/utils"
 import Content from "components/content/Content"
 import Title from "components/ui/Title"
 import { Event } from "lib/types"
 import { PageTemplate, pageTemplate } from "lib/pageTemplate"
+import excludeVariablesFromRoot from "@mui/material/styles/excludeVariablesFromRoot"
 
 type SectionComponentProps = {
   theme: Theme
@@ -16,6 +27,7 @@ type SectionComponentProps = {
   events: Event[]
   pageInfo?: PageTemplate
   repoUrl?: string
+  excludes?: Excludes
 }
 
 const SectionComponent: NextPage<SectionComponentProps> = ({
@@ -26,9 +38,18 @@ const SectionComponent: NextPage<SectionComponentProps> = ({
   material,
   pageInfo,
   repoUrl,
+  excludes,
 }: SectionComponentProps) => {
   return (
-    <Layout theme={theme} course={course} section={section} material={material} pageInfo={pageInfo} repoUrl={repoUrl}>
+    <Layout
+      theme={theme}
+      course={course}
+      section={section}
+      material={material}
+      pageInfo={pageInfo}
+      repoUrl={repoUrl}
+      excludes={excludes}
+    >
       <Title text={section.name} />
       <Content markdown={section.markdown} theme={theme} course={course} section={section} />
     </Layout>
@@ -61,6 +82,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const getStaticProps: GetStaticProps = async (context) => {
   const pageInfo = pageTemplate
   const repoId = context?.params?.repoId
+  const excludes = getExcludes(repoId as string)
   const repoUrl = getRepoUrl(repoId as string)
   const events = await prisma.event
     .findMany({
@@ -95,7 +117,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     return { notFound: true }
   }
   remove_markdown(material, section)
-  return { props: makeSerializable({ theme, course, section, events, material, pageInfo, repoUrl }) }
+  return { props: makeSerializable({ theme, course, section, events, material, pageInfo, repoUrl, excludes }) }
 }
 
 export default SectionComponent

--- a/pages/material/index.tsx
+++ b/pages/material/index.tsx
@@ -2,16 +2,10 @@ import type { NextPage, GetStaticProps } from "next"
 import prisma from "lib/prisma"
 import Layout from "components/Layout"
 import { makeSerializable } from "lib/utils"
-import { Material, getMaterial, remove_markdown } from "lib/material"
-import Content from "components/content/Content"
-import NavDiagram from "components/NavDiagram"
-import { EventFull as Event, EventFull } from "lib/types"
-import useSWR, { Fetcher } from "swr"
-import { basePath } from "lib/basePath"
-import useActiveEvent from "lib/hooks/useActiveEvents"
-import { Button, Card, theme } from "flowbite-react"
-import { concat } from "cypress/types/lodash"
+import { Material, getMaterial, remove_markdown, getExcludes } from "lib/material"
+import { EventFull as Event } from "lib/types"
 import { PageTemplate, pageTemplate } from "lib/pageTemplate"
+import ThemeCards from "components/ThemeCards"
 
 type HomeProps = {
   material: Material
@@ -20,25 +14,11 @@ type HomeProps = {
 }
 
 const Home: NextPage<HomeProps> = ({ material, events, pageInfo }) => {
-  const themeCards = generateThemeCards(material)
   return (
     <Layout material={material} pageInfo={pageInfo}>
-      <div className="items-stretch px-2 md:px-10 lg:px-10 xl:px-20 2xl:px-32 grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
-        {themeCards}
-      </div>
+      <ThemeCards material={material} />
     </Layout>
   )
-}
-
-function generateThemeCards(material: Material) {
-  const cards = material.themes.map((theme, index) => (
-    <Card key={theme.repo + theme.id} href={`${basePath}/material/${theme.repo}/${theme.id}`} className="w-90%">
-      <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{theme.name}</h5>
-      <p>{theme.summary}</p>
-    </Card>
-  ))
-
-  return cards
 }
 
 export const getStaticProps: GetStaticProps = async (context) => {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -46,3 +46,16 @@ ul:has(li.mdli) {
   list-style-type: disc !important;
   list-style-position: outside;
 }
+
+
+/* these css classes are used to style the chevron in the navbar when navdiagrams open */
+.collapsed {
+  /* Styles for chevron right */
+  transition: transform 0.3s ease;
+}
+
+.expanded {
+  /* Styles for chevron down */
+  transform: rotate(90deg);
+  transition: transform 0.3s ease;
+}


### PR DESCRIPTION
![navbarpopovers](https://github.com/OxfordRSE/gutenberg/assets/60351846/a7776a7e-7c11-4e6f-9e17-9625912df71c)



The only open question have is whether to move these mouse overs 1 element down.

Currently you mouse over course to see the available sections, theme to see the available courses and material to see the themes. The logic being its "explore element X"

They could all be moved 1 along such that mouseover on section shows sections etc. the logic here being its mouseover section to change the section.