### PR TITLE
enable template for html title

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,12 +16,12 @@ const Header: React.FC<Props> = ({ theme, course, pageInfo }) => {
   const logoSrc = pageInfo?.logo.src
   const logoAlt = pageInfo?.logo.alt
   const description = pageInfo?.description
+  const pageTitle = pageInfo?.title
   return (
     <Head>
-      <title>OxRSE Training</title>
-      {pageInfo && <meta name="description" content={description} />}
-      {pageInfo && <link rel="icon" href={logoSrc} />}
-
+      <title>{pageTitle}</title>
+        {pageInfo && <meta name="description" content={description} />}
+        {pageInfo && <link rel="icon" href={logoSrc} />}
       <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.4/flowbite.min.css" rel="stylesheet" />
     </Head>
   )

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -20,8 +20,8 @@ const Header: React.FC<Props> = ({ theme, course, pageInfo }) => {
   return (
     <Head>
       <title>{pageTitle}</title>
-        {pageInfo && <meta name="description" content={description} />}
-        {pageInfo && <link rel="icon" href={logoSrc} />}
+      {pageInfo && <meta name="description" content={description} />}
+      {pageInfo && <link rel="icon" href={logoSrc} />}
       <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.4/flowbite.min.css" rel="stylesheet" />
     </Head>
   )


### PR DESCRIPTION
closes #170 

This was in the config template but not in the header component. 

