### PR TITLE
fix: semantic HTML for page headings and paragraphs

### DIFF
--- a/components/content/Paragraph.tsx
+++ b/components/content/Paragraph.tsx
@@ -146,7 +146,7 @@ const Paragraph: React.FC<ParagraphProps> = ({ content, section }) => {
   return (
     <>
       <div data-cy="paragraph" ref={ref} className="relative pb-2">
-        {content}
+        <p className="m-0 pb-0">{content}</p>
         {activeEvent && (
           <div className={`absolute top-0 right-0 md:-right-6 xl:-right-[420px]`}>
             <div className={`w-[420px]`}>

--- a/components/ui/Title.tsx
+++ b/components/ui/Title.tsx
@@ -6,9 +6,9 @@ type Props = {
 
 const Header: React.FC<Props> = (props) => {
   return (
-    <p className="text-center text-2xl font-bold mb-4" data-cy="title">
+    <h1 className="text-center text-2xl font-bold mb-4" data-cy="title">
       {props.text}
-    </p>
+    </h1>
   )
 }
 


### PR DESCRIPTION
- Wrap the main content heading in `h1`, instead of `p`.
- Wrap paragraph content in `p` tags.

Towards [WCAG 2 Success Criterion 1.3.1 (Info and relationships)](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships). This should make pages easier to navigate with a screen reader, particularly for readers who use page headings to navigate.