### PR TITLE
fix(a11y): accessible accordion controls for Solutions

### DIFF
--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -56,8 +56,10 @@ const list = (sectionStr: string) => {
   return list
 }
 
+let solutionCount = 0
 function solution({ node, children, ...props }: ReactMarkdownProps) {
-  return <Solution content={children} />
+  solutionCount++
+  return <Solution id={`solution-${solutionCount}`} content={children} />
 }
 
 type CalloutProps = ReactMarkdownProps & {

--- a/components/content/Solution.tsx
+++ b/components/content/Solution.tsx
@@ -2,10 +2,11 @@ import React, { useRef, useState } from "react"
 import Accordion from "../ui/Accordian"
 
 interface SolutionProps {
+  id: string
   content: React.ReactNode
 }
 
-const Solution: React.FC<SolutionProps> = ({ content }) => {
+const Solution: React.FC<SolutionProps> = ({ id, content }) => {
   const [active, setActive] = useState(false)
   const [height, setHeight] = useState("0px")
   const [rotate, setRotate] = useState("transform duration-700 ease")
@@ -20,11 +21,16 @@ const Solution: React.FC<SolutionProps> = ({ content }) => {
   }
 
   const title = "Solution"
+  const headingId = `${id}-heading`
+  const panelId = `${id}-panel`
 
   return (
     <div className="pt-1 flex flex-col">
       <button
-        className="rounded bg-slate-200 dark:bg-slate-700 font-bold appearance-none cursor-pointer focus:outline-none flex items-center justify-between"
+        id={headingId}
+        aria-expanded={active ? "true" : "false"}
+        aria-controls={panelId}
+        className="rounded bg-slate-200 dark:bg-slate-700 font-bold appearance-none cursor-pointer flex items-center justify-between"
         onClick={toggleAccordion}
       >
         <p className="px-4 my-2">{title}</p>
@@ -43,7 +49,11 @@ const Solution: React.FC<SolutionProps> = ({ content }) => {
         </svg>
       </button>
       <div
+        id={panelId}
         ref={contentSpace}
+        role="region"
+        aria-labelledby={headingId}
+        aria-hidden={active ? "false" : "true"}
         style={{ maxHeight: `${height}` }}
         className="overflow-hidden transition-max-height duration-700 ease-in-out"
       >


### PR DESCRIPTION
- remove the `outline: none` focus styling from Solutions buttons.
- add ARIA roles and states as per the [accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/).