### PR TITLE
Add a Docker compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,66 @@
+# This dictates the branch of the Dockerfile to use, i.e. to pull, copy or use a 
+# placeholder for mounting the course material in. The appropriate values for 
+# $MATERIAL_METHOD are therefore ["pull", "copy", "placeholder"]
+ARG MATERIAL_METHOD=copy
+
+# Define the Python version to use
+ARG PYTHON_VERSION=3.12.3-slim
+
+####
+# MATERIAL OPTION: PULL
+# Pull course material into the app directory from a defined repo. Default is
+# the Oxford course material repo defined in the config/oxford.yaml file.
+FROM python:${PYTHON_VERSION} AS pull_material
+
+# Variables for the material pull script
+ARG YAML_TEMPLATE=config/oxford.yaml
+ARG MATERIAL_DIR=.material
+
+# Copy the scripts and config files into the container
+ONBUILD WORKDIR /app
+ONBUILD COPY ../scripts/ /app/scripts/
+ONBUILD COPY ../config/ /app/config/
+
+# Install dependencies and pull the material into the container with git
+ONBUILD RUN \
+    apt-get update && \
+    apt-get install -y git && \
+    apt-get clean && \
+    pip install --upgrade pip setuptools wheel && \
+    pip install -r scripts/python_requirements.txt && \
+    python scripts/pull_material.py
+
+####
+# MATERIAL OPTION: COPY
+# Copy existing course material into this container for the build
+FROM python:${PYTHON_VERSION} AS copy_material
+
+ARG MATERIAL_DIR=.material
+# Material dir may not exist yet, so we pass COPY a file which we know will be 
+# in context (i.e. the entrypoint script) to ensure the COPY command doesn't 
+# fail 
+ONBUILD COPY ../entrypoint.sh ../${MATERIAL_DIR}* /app/${MATERIAL_DIR}/
+
+
+####
+# MATERIAL OPTION: PLACEHOLDER
+# Make a placeholder directory for the material so we can mount over it later on
+FROM python:${PYTHON_VERSION} AS placeholder_material
+
+ARG MATERIAL_DIR=.material
+ONBUILD RUN \
+    mkdir -p /app/${MATERIAL_DIR}/HPCu && \
+    touch /app/${MATERIAL_DIR}/HPCu/index.md
+
+
+# Here we use the MATERIAL_METHOD arg to determine which method we use to get 
+# material into our container for build time.
+FROM ${MATERIAL_METHOD}_material as material
+
+#### 
+# BUILDER
+# Build the app with yarn or npm
+
 # Install dependencies only when needed
 FROM node:20.9-alpine AS builder
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
@@ -29,7 +92,10 @@ ARG DATABASE_URL
 ENV DATABASE_URL ${DATABASE_URL}
 ARG NEXT_PUBLIC_PLAUSIBLE_DOMAIN
 ENV NEXT_PUBLIC_PLAUSIBLE_DOMAIN ${NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
-RUN npx prisma migrate deploy
+
+# Copy the course material into this container for the build
+ARG MATERIAL_DIR=.material
+COPY --from=material /app/${MATERIAL_DIR} /app/${MATERIAL_DIR}
 
 RUN yarn build
 
@@ -45,6 +111,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 COPY --from=builder --chown=nextjs:nextjs /app ./
+COPY ./prisma /app/prisma
 
 USER nextjs
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,48 @@ To see our full documentation, please visit [our documentation site](https://blo
 
 To get a development environment running, follow the instructions below:
 
-## Getting started
+## Getting started (using Docker-compose)
+
+Gutenberg now has a deployable dev environment using docker-compose. For this 
+you'll need the following software: 
+
+- `git` version 2.43.0 or later
+- `docker` version 18.03 or later
+
+Both of which will need to be installed following instructions for your system.
+
+Then we can get started by cloning the repository with git and entering into it
+with `cd`:
+``` bash
+git clone https://github.com/OxfordRSE/gutenberg.git`
+cd gutenberg 
+```
+
+From here we can simply run:
+```
+docker-compose up
+```
+
+which should make gutenberg available to you at http://localhost:3000. This will 
+build a Docker image the first time you run it (assuming you don't already have 
+an image called `gutenburg` in your local registry) from the local source code - 
+this might take a few minutes. If you want to force a rebuild after you've made 
+some changes you can append the `--build` flag after `up`, i.e. 
+
+```
+docker-compose up --build
+```
+
+Although this isn't particularly quick. By default the compose setup will pull 
+the repo from the source defined in `config/oxford.yaml`, though you can change 
+this from inside the `dev-compose.yml`, either by changing the `YAML_TEMPLATE` 
+value (under `services.gutenberg.build.args`) to a different config yaml file or 
+changing `MATERIAL_METHOD` to `"copy"` to copy a locally checked out folder into 
+the container at build-time instead of pulling fresh - for more details on how 
+to pull material to edit locally follow the below section. 
+
+
+## Getting started (installing locally)
 
 Setting up a local development requires the following software:
 

--- a/dev-compose.yml
+++ b/dev-compose.yml
@@ -3,7 +3,7 @@ version: '3.9'
 
 x-vol-args: &args
   volumes: 
-    - ./.material-bk:/app/.material
+    - ./.material:/app/.material
 
 services:
   db:

--- a/dev-compose.yml
+++ b/dev-compose.yml
@@ -15,15 +15,6 @@ services:
       POSTGRES_USER: postgres
     ports:
       - "5432:5432"
-
-  # py-matpull:
-  #   image: python-matpull
-  #   build: 
-  #     context: scripts/.
-  #     dockerfile: Dockerfile
-  #     args:
-  #       MATERIAL_METHOD: "placeholder"
-  #   <<: *args
     
   gutenberg:
     image: gutenberg
@@ -31,10 +22,6 @@ services:
       context: .
       dockerfile: Dockerfile
       args: 
-        # Here we use the magical 'host.docker.internal' to connect to the host 
-        # the db container is running on (i.e. the developer's machine in a dev 
-        # environment). Will work if port 5432 is exposed on the db service.
-        # DATABASE_URL: postgresql://postgres:super-secret-password@host.docker.internal:5432
         MATERIAL_METHOD: "pull"
         MATERIAL_DIR: ".material"
         YAML_TEMPLATE: "config/oxford.yaml"
@@ -46,10 +33,5 @@ services:
     depends_on:
       db:
         condition: service_started
-      # py-matpull:
-      #   condition: service_completed_successfully
     environment:
       DATABASE_URL: postgresql://postgres:super-secret-password@db:5432
-
-# volumes:
-#   - ./.material:/app/.material

--- a/dev-compose.yml
+++ b/dev-compose.yml
@@ -1,0 +1,55 @@
+# Use postgres/example user/password credentials
+version: '3.9'
+
+x-vol-args: &args
+  volumes: 
+    - ./.material-bk:/app/.material
+
+services:
+  db:
+    image: postgres
+    restart: always
+    shm_size: 128mb
+    environment:
+      POSTGRES_PASSWORD: super-secret-password
+      POSTGRES_USER: postgres
+    ports:
+      - "5432:5432"
+
+  # py-matpull:
+  #   image: python-matpull
+  #   build: 
+  #     context: scripts/.
+  #     dockerfile: Dockerfile
+  #     args:
+  #       MATERIAL_METHOD: "placeholder"
+  #   <<: *args
+    
+  gutenberg:
+    image: gutenberg
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args: 
+        # Here we use the magical 'host.docker.internal' to connect to the host 
+        # the db container is running on (i.e. the developer's machine in a dev 
+        # environment). Will work if port 5432 is exposed on the db service.
+        # DATABASE_URL: postgresql://postgres:super-secret-password@host.docker.internal:5432
+        MATERIAL_METHOD: "pull"
+        MATERIAL_DIR: ".material"
+        YAML_TEMPLATE: "config/oxford.yaml"
+    ports:
+      - "3000:3000"
+    links: 
+      - db
+    <<: *args
+    depends_on:
+      db:
+        condition: service_started
+      # py-matpull:
+      #   condition: service_completed_successfully
+    environment:
+      DATABASE_URL: postgresql://postgres:super-secret-password@db:5432
+
+# volumes:
+#   - ./.material:/app/.material

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
+
+# Run migrations on the database
+RUN npx prisma migrate deploy
+
 yarn cron &
 yarn start


### PR DESCRIPTION
Adds a docker compose file which can be used for easily getting up and running with a local dev environment, addressing #121 (partially) and #194. Moves database migration to the entrypoint script so that a working database is not required at build-time.

Also adds material-pulling into the Dockerfile with controllable behaviour via the `MATERIAL_METHOD` build-arg, either:
- `"copy"` in a local folder, specified by `MATERIAL_DIR`
- `"pull"` the repo described in a local config yaml file, specified by `YAML_TEMPLATE`
The pull option is the default, and uses the recently added python script functionality. 

Note that the local `.material` is mounted in at run time, but doesn't seem to get updated with the cron job. 

Works as-is but could probably be improved in a few ways:
1. An additional Dockerfile/option to use `yarn dev` to cut down on build iteration time (maybe `dev-dynamic-compose.yml`)
2. Split the material pulling stuff into a separate image
3. Get the mounted material directory to be refreshed from by the cronjob 
4. Use the test material repo set up for #189
5. Implement a production version with NGINX and qdrant
 