### PR TITLE
Styling improvements for [sectionId] pages

### DIFF
--- a/components/content/LearningOutcomes.tsx
+++ b/components/content/LearningOutcomes.tsx
@@ -30,7 +30,7 @@ export default function LearningOutcomes({ learningOutcomes }: { learningOutcome
           {learningOutcomes.map((o, i) => (
             <ListItem key={i}>
               <ListItemIcon>
-                <HiOutlineTrophy className="dark: stroke-teal-50" />
+                <HiOutlineTrophy color="#2e7d32" />
               </ListItemIcon>
               <ListItemText>{o}</ListItemText>
             </ListItem>

--- a/components/content/LearningOutcomes.tsx
+++ b/components/content/LearningOutcomes.tsx
@@ -17,7 +17,7 @@ export default function LearningOutcomes({ learningOutcomes }: { learningOutcome
   return (
     <Alert
       severity="success"
-      className="max-w-2xl mx-auto dark:bg-green-950 dark:text-teal-50"
+      className="max-w-2xl mx-auto dark:bg-indigo-950 dark:text-teal-50"
       sx={{ marginBottom: (t: Theme) => t.spacing(1) }}
     >
       <Tooltip title={`Click to ${open ? "hide" : "show"} learning outcomes`}>

--- a/components/content/LearningOutcomes.tsx
+++ b/components/content/LearningOutcomes.tsx
@@ -15,7 +15,7 @@ export default function LearningOutcomes({ learningOutcomes }: { learningOutcome
   const [open, setOpen] = React.useState(true)
   if (learningOutcomes.length === 0) return null
   return (
-    <Alert severity="success" sx={{ marginBottom: (t: Theme) => t.spacing(1) }}>
+    <Alert severity="success" className="max-w-2xl mx-auto dark:bg-[#0C130D] dark:text-[#CCE8ED]" sx={{ marginBottom: (t: Theme) => t.spacing(1) }}>
       <Tooltip title={`Click to ${open ? "hide" : "show"} learning outcomes`}>
         <Typography variant="body2" onClick={() => setOpen(!open)} sx={{ cursor: "pointer" }}>
           Learning outcomes
@@ -26,7 +26,7 @@ export default function LearningOutcomes({ learningOutcomes }: { learningOutcome
           {learningOutcomes.map((o, i) => (
             <ListItem key={i}>
               <ListItemIcon>
-                <HiOutlineTrophy />
+                <HiOutlineTrophy className="dark: stroke-[#CCE8ED]" />
               </ListItemIcon>
               <ListItemText>{o}</ListItemText>
             </ListItem>

--- a/components/content/LearningOutcomes.tsx
+++ b/components/content/LearningOutcomes.tsx
@@ -17,7 +17,7 @@ export default function LearningOutcomes({ learningOutcomes }: { learningOutcome
   return (
     <Alert
       severity="success"
-      className="max-w-2xl mx-auto dark:bg-green-950 dark:text-teal-50 dark:"
+      className="max-w-2xl mx-auto dark:bg-green-950 dark:text-teal-50"
       sx={{ marginBottom: (t: Theme) => t.spacing(1) }}
     >
       <Tooltip title={`Click to ${open ? "hide" : "show"} learning outcomes`}>

--- a/components/content/LearningOutcomes.tsx
+++ b/components/content/LearningOutcomes.tsx
@@ -15,7 +15,11 @@ export default function LearningOutcomes({ learningOutcomes }: { learningOutcome
   const [open, setOpen] = React.useState(true)
   if (learningOutcomes.length === 0) return null
   return (
-    <Alert severity="success" className="max-w-2xl mx-auto dark:bg-[#0C130D] dark:text-[#CCE8ED]" sx={{ marginBottom: (t: Theme) => t.spacing(1) }}>
+    <Alert
+      severity="success"
+      className="max-w-2xl mx-auto dark:bg-[#0C130D] dark:text-[#CCE8ED]"
+      sx={{ marginBottom: (t: Theme) => t.spacing(1) }}
+    >
       <Tooltip title={`Click to ${open ? "hide" : "show"} learning outcomes`}>
         <Typography variant="body2" onClick={() => setOpen(!open)} sx={{ cursor: "pointer" }}>
           Learning outcomes

--- a/components/content/LearningOutcomes.tsx
+++ b/components/content/LearningOutcomes.tsx
@@ -17,7 +17,7 @@ export default function LearningOutcomes({ learningOutcomes }: { learningOutcome
   return (
     <Alert
       severity="success"
-      className="max-w-2xl mx-auto dark:bg-[#0C130D] dark:text-[#CCE8ED]"
+      className="max-w-2xl mx-auto dark:bg-green-950 dark:text-teal-50 dark:"
       sx={{ marginBottom: (t: Theme) => t.spacing(1) }}
     >
       <Tooltip title={`Click to ${open ? "hide" : "show"} learning outcomes`}>
@@ -30,7 +30,7 @@ export default function LearningOutcomes({ learningOutcomes }: { learningOutcome
           {learningOutcomes.map((o, i) => (
             <ListItem key={i}>
               <ListItemIcon>
-                <HiOutlineTrophy className="dark: stroke-[#CCE8ED]" />
+                <HiOutlineTrophy className="dark: stroke-teal-50" />
               </ListItemIcon>
               <ListItemText>{o}</ListItemText>
             </ListItem>

--- a/components/ui/LinkedSection.tsx
+++ b/components/ui/LinkedSection.tsx
@@ -45,6 +45,10 @@ export const LinkedSection = (sectionLink: SectionLink) => {
     (sectionLink.course ? sectionLink.course + " - " : "") +
     (sectionLink.section ? sectionLink.section : "")
 
+  const calcAnchorHeight = () => {
+    sectionLink.section!.length > 16 ? `h-[105px]` : `h-[80px]`
+  }
+
   let stackDirection
   let navIcon
   if (sectionLink.direction === "prev") {
@@ -59,7 +63,7 @@ export const LinkedSection = (sectionLink: SectionLink) => {
     <Tooltip title={tooltipTitle}>
       <a href={`${sectionLink.url}`} className={`pointer-events-auto text-gray-600 hover:text-gray-500 opacity-50`}>
         <div
-          className={`group rounded-md border-2 hover:border-4 ${borderColor} h-[55px] w-[150px] text-sm`}
+          className={`group rounded-md border-2 hover:border-4 ${borderColor} ${calcAnchorHeight} w-[150px] text-sm`}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >


### PR DESCRIPTION
- Fixed text overflowing prev/next buttons - #177 
- Style improvements for learning outcomes as per #229   
<img width="1330" alt="Section Styling" src="https://github.com/OxfordRSE/gutenberg/assets/10367135/a4b20bac-dd15-4fc5-9df9-e797c9d4a578">

+ tailwind colours
<img width="768" alt="Screenshot 2024-06-27 at 15 23 28" src="https://github.com/OxfordRSE/gutenberg/assets/10367135/fcb9a92f-15c9-45a2-a970-b6295683eb68">
