### PR TITLE
Mobile and narrow-resolution improvements

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -17,8 +17,8 @@ const Footer: React.FC<Props> = ({ pageInfo }) => {
         {footerAttrib && <Markdown markdown={"© " + new Date().getFullYear() + " " + footerAttrib} />}
       </span>
       
-      <div className="flex justify-evenly gap-5 content-center">
-        <p className="flex flex-wrap items-center mt-3 text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
+      <div className="flex justify-evenly gap-5 items-center mt-3">
+        <p className="flex flex-wrap items-center text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
           For attribution and license information click the @ symbol on the top right
         </p>
         <ThemeButton />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -17,7 +17,7 @@ const Footer: React.FC<Props> = ({ pageInfo }) => {
         {footerAttrib && <Markdown markdown={"© " + new Date().getFullYear() + " " + footerAttrib} />}
       </span>
       
-      <div className="flex justify-evenly gap-5 items-center mt-3">
+      <div className="flex justify-evenly gap-5 items-center mt-3 md:mt-0">
         <p className="flex flex-wrap items-center text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
           For attribution and license information click the @ symbol on the top right
         </p>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,14 +12,17 @@ interface Props {
 const Footer: React.FC<Props> = ({ pageInfo }) => {
   const footerAttrib = pageInfo?.footer
   return (
-    <footer className="mt-4 mb-2 mx-2 p-2 bg-white rounded-lg shadow md:flex md:items-center md:justify-between dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+    <footer className="mt-4 mb-2 mx-2 p-2 bg-white rounded-lg shadow md:flex md:items-center md:justify-between md:gap-2 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
       <span className="flex flex-wrap text-sm text-gray-500 sm:text-center dark:text-gray-400">
         {footerAttrib && <Markdown markdown={"© " + new Date().getFullYear() + " " + footerAttrib} />}
       </span>
-      <p className="flex flex-wrap items-center mt-3 text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
-        For attribution and license information click the @ symbol on the top right
-      </p>
-      <ThemeButton />
+      
+      <div className="flex justify-evenly gap-5 content-center">
+        <p className="flex flex-wrap items-center mt-3 text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
+          For attribution and license information click the @ symbol on the top right
+        </p>
+        <ThemeButton />
+      </div>
     </footer>
   )
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -16,7 +16,7 @@ const Footer: React.FC<Props> = ({ pageInfo }) => {
       <span className="flex flex-wrap text-sm text-gray-500 sm:text-center dark:text-gray-400">
         {footerAttrib && <Markdown markdown={"© " + new Date().getFullYear() + " " + footerAttrib} />}
       </span>
-      
+
       <div className="flex justify-evenly gap-5 items-center mt-3 md:mt-0">
         <p className="flex flex-wrap items-center text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
           For attribution and license information click the @ symbol on the top right

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -120,7 +120,6 @@ const Navbar: React.FC<Props> = ({
 
   const toggleDrawer = (open: boolean) => {
     setDrawerOpen(open)
-    console.log(drawerOpen)
   }
 
   return (
@@ -301,7 +300,12 @@ const Navbar: React.FC<Props> = ({
           >
             <MenuIcon />
           </IconButton>
-          <Drawer open={drawerOpen}>
+          <Drawer
+            PaperProps={{
+              className: "bg-gray-50 dark:bg-gray-800",
+            }}
+            open={drawerOpen}
+          >
             <Box sx={{ width: 250 }}>
               <IconButton onClick={() => toggleDrawer(false)} sx={{ p: 2 }}>
                 <CloseIcon />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -44,6 +44,8 @@ const Navbar: React.FC<Props> = ({
   const [isPopoverHovered, setIsPopoverHovered] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
   const [itemHovered, setItemHovered] = useState("")
+  const [width, setWidth] = useState<number>(0)
+  const breakpoint = 900
   const { data: session } = useSession()
   const ref1 = useRef<HTMLLIElement>(null)
   const ref2 = useRef<HTMLLIElement>(null)
@@ -85,6 +87,20 @@ const Navbar: React.FC<Props> = ({
     }
   }, [isHovered, isPopoverHovered])
 
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(window.innerWidth);
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
   const handleIsHovered = (hovered: string) => {
     clearTimeout(leaveTimer)
     setItemHovered(hovered)
@@ -107,7 +123,10 @@ const Navbar: React.FC<Props> = ({
   }
 
   return (
+    // remove width !
     <div className="z-10 flex p-2 mx-2 mt-2 mb-4 text-gray-700 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+      {width}
+      {width > breakpoint ? (
       <nav className="w-full inline-flex" aria-label="Breadcrumb">
         <ol className="z-10 list-none inline-flex items-center space-x-1 md:space-x-3">
           {activeEvent && (
@@ -262,7 +281,7 @@ const Navbar: React.FC<Props> = ({
             </li>
           )}
         </ol>
-      </nav>
+      </nav>) : <p>Too small</p>}
       <ul aria-label="Page tools" className="gap-1 relative flex list-none items-center">
         {theme && course && section && (
           <li className="inline-flex">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -55,7 +55,7 @@ const Navbar: React.FC<Props> = ({
   const [drawerOpen, setDrawerOpen] = useState(false)
   const windowSize = useWindowSize()
   const breakpoint = 900
-  const burgerDrawerMaterialMargin = "ml-3"
+  const burgerDrawerMaterialMargin = "ml-9"
   const { data: session } = useSession()
   const ref1 = useRef<HTMLLIElement>(null)
   const ref2 = useRef<HTMLLIElement>(null)
@@ -331,14 +331,22 @@ const Navbar: React.FC<Props> = ({
                           href={`/material`}
                           className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
                         >
-                    
-                        <span className="pb-2">Material</span>
-                    
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            height="24px"
+                            viewBox="0 -960 960 960"
+                            className="w-4 h-4 mr-2 mb-2"
+                            fill="currentColor"
+                          >
+                            <path d="M260-320q47 0 91.5 10.5T440-278v-394q-41-24-87-36t-93-12q-36 0-71.5 7T120-692v396q35-12 69.5-18t70.5-6Zm260 42q44-21 88.5-31.5T700-320q36 0 70.5 6t69.5 18v-396q-33-14-68.5-21t-71.5-7q-47 0-93 12t-87 36v394Zm-40 118q-48-38-104-59t-116-21q-42 0-82.5 11T100-198q-21 11-40.5-1T40-234v-482q0-11 5.5-21T62-752q46-24 96-36t102-12q58 0 113.5 15T480-740q51-30 106.5-45T700-800q52 0 102 12t96 36q11 5 16.5 15t5.5 21v482q0 23-19.5 35t-40.5 1q-37-20-77.5-31T700-240q-60 0-116 21t-104 59ZM280-494Z" />
+                          </svg>
+                          <span className="pb-2">Material</span>
                         </Link>
-                    
                       </div>
                     </li>
-                    <li><Divider variant="fullWidth" /></li>
+                    <li>
+                      <Divider variant="fullWidth" />
+                    </li>
                   </ol>
                 )}
                 {theme && (
@@ -370,7 +378,9 @@ const Navbar: React.FC<Props> = ({
                 {section && (
                   <li aria-current="page">
                     <div className="flex items-center">
-                      <span className={`${burgerDrawerMaterialMargin} text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white`}>
+                      <span
+                        className={`${burgerDrawerMaterialMargin} text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white`}
+                      >
                         {section.name}
                       </span>
                     </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -327,9 +327,10 @@ const Navbar: React.FC<Props> = ({
                     <div className="flex items-center">
                       <Link
                         href={`/material`}
-                        className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
+                        className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
                       >
-                        Material
+                        
+                      Material
                       </Link>
                     </div>
                   </li>
@@ -357,19 +358,18 @@ const Navbar: React.FC<Props> = ({
                       >
                         {course.name}
                       </Link>
-                      
                     </div>
                   </li>
                 )}{" "}
                 {section && (
-              <li aria-current="page">
-                <div className="flex items-center">
-                  <span className="ml-1 text-sm font-medium text-gray-500 md:ml-2 dark:text-gray-400">
-                    {section.name}
-                  </span>
-                </div>
-              </li>
-            )}
+                  <li aria-current="page">
+                    <div className="flex items-center">
+                      <span className="ml-1 text-sm font-medium text-gray-500 md:ml-2 dark:text-gray-400">
+                        {section.name}
+                      </span>
+                    </div>
+                  </li>
+                )}
               </ol>
             </Box>
           </Drawer>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -12,7 +12,10 @@ import { enableSearch } from "lib/search/enableSearch"
 import NavDiagramPopover from "./dialogs/navDiagramPop"
 import ThemeCardsPopover from "./dialogs/themeCardPop"
 import { IconButton } from "@mui/material"
-import MenuIcon from '@mui/icons-material/Menu';
+import MenuIcon from "@mui/icons-material/Menu"
+import Drawer from "@mui/material/Drawer"
+import CloseIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box"
 import useWindowSize from "lib/hooks/useWindowSize"
 
 interface Props {
@@ -49,6 +52,7 @@ const Navbar: React.FC<Props> = ({
   const [itemHovered, setItemHovered] = useState("")
   const [width, setWidth] = useState<number>(0)
   const [menu, setMenu] = useState(false)
+  const [drawerOpen, setDrawerOpen] = useState(false)
   const windowSize = useWindowSize()
   const breakpoint = 900
   const { data: session } = useSession()
@@ -113,11 +117,16 @@ const Navbar: React.FC<Props> = ({
     setIsPopoverHovered(false)
   }
 
+  const toggleDrawer = (open: boolean) => {
+    setDrawerOpen(open)
+    console.log(drawerOpen)
+  }
+
   return (
     // remove width !
     <div className="z-10 flex p-2 mx-2 mt-2 mb-4 text-gray-700 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700 justify-between">
       {/* {windowSize.width} */}
-      {(windowSize.width ?? 1024) >= 1024 ?  (
+      {(windowSize.width ?? 1024) >= 1024 ? (
         <nav className="w-full inline-flex" aria-label="Breadcrumb">
           <ol className="z-10 list-none inline-flex items-center space-x-1 md:space-x-3">
             {activeEvent && (
@@ -134,7 +143,12 @@ const Navbar: React.FC<Props> = ({
                 href="/"
                 className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
               >
-                <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <svg
+                  className="w-4 h-4 mr-2"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
                   <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path>
                 </svg>
                 Home
@@ -274,9 +288,26 @@ const Navbar: React.FC<Props> = ({
           </ol>
         </nav>
       ) : (
-        <IconButton size="large" edge="start" color="inherit" aria-label="menu" className="text-gray-400 px-5"sx={{ mr: 2 }}>
-          <MenuIcon />
-        </IconButton>
+        <div>
+          <IconButton
+            onClick={() => toggleDrawer(true)}
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            className="text-gray-400 ml-1"
+            sx={{ mr: 2 }}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Drawer open={drawerOpen}>
+            <Box  sx={{width: 250}}>
+            <IconButton onClick={() => toggleDrawer(false)} sx={{ p: 2 }}>
+                <CloseIcon />
+              </IconButton>
+            </Box>
+          </Drawer>
+        </div>
       )}
       <ul aria-label="Page tools" className="gap-1 relative flex list-none items-center">
         {theme && course && section && (

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -47,6 +47,7 @@ const Navbar: React.FC<Props> = ({
   const [isHovered, setIsHovered] = useState(false)
   const [itemHovered, setItemHovered] = useState("")
   const [width, setWidth] = useState<number>(0)
+  const [menu, setMenu] = useState(false)
   const breakpoint = 900
   const { data: session } = useSession()
   const ref1 = useRef<HTMLLIElement>(null)
@@ -289,7 +290,7 @@ const Navbar: React.FC<Props> = ({
           <MenuIcon />
         </IconButton>
       )}
-      <ul aria-label="Page tools" className="gap-1 relative flex list-none items-center">
+      <ul aria-label="Page tools" className="gap-1 relative flex list-none items-center justify-end">
         {theme && course && section && (
           <li className="inline-flex">
             <Link

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -302,13 +302,13 @@ const Navbar: React.FC<Props> = ({
           </IconButton>
           <Drawer
             PaperProps={{
-              className: "bg-gray-50 dark:bg-gray-800",
+              className: "bg-gray-50 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700",
             }}
             open={drawerOpen}
           >
             <Box sx={{ width: 250 }}>
               <IconButton onClick={() => toggleDrawer(false)} sx={{ p: 2 }}>
-                <CloseIcon />
+                <CloseIcon className="stroke-slate-400 fill-slate-400" />
               </IconButton>
               <ol className="p-5 flex flex-col gap-3">
                 <li className="inline-flex items-center">
@@ -349,7 +349,7 @@ const Navbar: React.FC<Props> = ({
                       </div>
                     </li>
                     <li>
-                      <Divider variant="fullWidth" />
+                      <Divider variant="fullWidth" className="dark:bg-slate-400" />
                     </li>
                   </ol>
                 )}
@@ -383,7 +383,7 @@ const Navbar: React.FC<Props> = ({
                   <li aria-current="page">
                     <div className="flex items-center">
                       <span
-                        className={`${burgerDrawerMaterialMargin} text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white`}
+                        className={`${burgerDrawerMaterialMargin} text-sm font-medium text-gray-700 dark:text-gray-400 `}
                       >
                         {section.name}
                       </span>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -305,7 +305,7 @@ const Navbar: React.FC<Props> = ({
               <IconButton onClick={() => toggleDrawer(false)} sx={{ p: 2 }}>
                 <CloseIcon />
               </IconButton>
-              <ol className="p-5 flex-col">
+              <ol className="p-5 flex flex-col gap-2">
                 <li className="inline-flex items-center">
                   <Link
                     href="/"
@@ -357,18 +357,19 @@ const Navbar: React.FC<Props> = ({
                       >
                         {course.name}
                       </Link>
+                      
                     </div>
                   </li>
                 )}{" "}
                 {section && (
-                  <li aria-current="page">
-                    <div className="flex items-center">
-                      <span className="ml-1 text-sm font-medium text-gray-500 md:ml-2 dark:text-gray-400">
-                        {section.name}
-                      </span>
-                    </div>
-                  </li>
-                )}
+              <li aria-current="page">
+                <div className="flex items-center">
+                  <span className="ml-1 text-sm font-medium text-gray-500 md:ml-2 dark:text-gray-400">
+                    {section.name}
+                  </span>
+                </div>
+              </li>
+            )}
               </ol>
             </Box>
           </Drawer>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -359,7 +359,7 @@ const Navbar: React.FC<Props> = ({
             )}
           </Dropdown>
         </li>
-        <li className="h-full border-l border-gray-500 ps-1">
+        <li className="h-full border-l border-gray-500 ps-1 flex items-center">
           <Tooltip content="Licensing and Attribution">
             <button
               aria-label="Licensing and Attribution"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -13,6 +13,7 @@ import NavDiagramPopover from "./dialogs/navDiagramPop"
 import ThemeCardsPopover from "./dialogs/themeCardPop"
 import { IconButton } from "@mui/material"
 import MenuIcon from '@mui/icons-material/Menu';
+import useWindowSize from "lib/hooks/useWindowSize"
 
 interface Props {
   material: Material
@@ -48,6 +49,7 @@ const Navbar: React.FC<Props> = ({
   const [itemHovered, setItemHovered] = useState("")
   const [width, setWidth] = useState<number>(0)
   const [menu, setMenu] = useState(false)
+  const windowSize = useWindowSize()
   const breakpoint = 900
   const { data: session } = useSession()
   const ref1 = useRef<HTMLLIElement>(null)
@@ -90,20 +92,6 @@ const Navbar: React.FC<Props> = ({
     }
   }, [isHovered, isPopoverHovered])
 
-  useEffect(() => {
-    const handleResize = () => {
-      setWidth(window.innerWidth)
-    }
-
-    handleResize()
-
-    window.addEventListener("resize", handleResize)
-
-    return () => {
-      window.removeEventListener("resize", handleResize)
-    }
-  }, [])
-
   const handleIsHovered = (hovered: string) => {
     clearTimeout(leaveTimer)
     setItemHovered(hovered)
@@ -128,8 +116,8 @@ const Navbar: React.FC<Props> = ({
   return (
     // remove width !
     <div className="z-10 flex p-2 mx-2 mt-2 mb-4 text-gray-700 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
-      {width}
-      {width > breakpoint ? (
+      {windowSize.width}
+      {(windowSize.width ?? 1024) >= 1024 ?  (
         <nav className="w-full inline-flex" aria-label="Breadcrumb">
           <ol className="z-10 list-none inline-flex items-center space-x-1 md:space-x-3">
             {activeEvent && (

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -11,6 +11,8 @@ import { useRecoilState } from "recoil"
 import { enableSearch } from "lib/search/enableSearch"
 import NavDiagramPopover from "./dialogs/navDiagramPop"
 import ThemeCardsPopover from "./dialogs/themeCardPop"
+import { IconButton } from "@mui/material"
+import MenuIcon from '@mui/icons-material/Menu';
 
 interface Props {
   material: Material
@@ -89,17 +91,17 @@ const Navbar: React.FC<Props> = ({
 
   useEffect(() => {
     const handleResize = () => {
-      setWidth(window.innerWidth);
-    };
+      setWidth(window.innerWidth)
+    }
 
-    handleResize();
+    handleResize()
 
-    window.addEventListener('resize', handleResize);
+    window.addEventListener("resize", handleResize)
 
     return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [])
 
   const handleIsHovered = (hovered: string) => {
     clearTimeout(leaveTimer)
@@ -127,161 +129,166 @@ const Navbar: React.FC<Props> = ({
     <div className="z-10 flex p-2 mx-2 mt-2 mb-4 text-gray-700 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
       {width}
       {width > breakpoint ? (
-      <nav className="w-full inline-flex" aria-label="Breadcrumb">
-        <ol className="z-10 list-none inline-flex items-center space-x-1 md:space-x-3">
-          {activeEvent && (
-            <>
-              <HiCalendar
-                className="pointer-events-auto cursor-pointer text-gray-500 hover:text-gray-400 w-10 h-10"
-                onClick={handleToggle}
-              />
-              <div className="h-full border-r border-gray-500"></div>
-            </>
-          )}
-          <li className="inline-flex items-center">
-            <Link
-              href="/"
-              className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >
-              <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path>
-              </svg>
-              Home
-            </Link>
-          </li>
-          {theme && (
-            <li ref={ref1} onMouseEnter={() => handleIsHovered("theme")} onMouseLeave={handleIsNotHovered}>
-              <div className="flex items-center">
-                <svg
-                  className="w-6 h-6 text-gray-400"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    className={showNavDiagram && itemHovered === "theme" ? "expanded" : "collapsed"}
-                    style={{ transformOrigin: "50% 50%" }}
-                    fillRule="evenodd"
-                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                    clipRule="evenodd"
-                  ></path>
+        <nav className="w-full inline-flex" aria-label="Breadcrumb">
+          <ol className="z-10 list-none inline-flex items-center space-x-1 md:space-x-3">
+            {activeEvent && (
+              <>
+                <HiCalendar
+                  className="pointer-events-auto cursor-pointer text-gray-500 hover:text-gray-400 w-10 h-10"
+                  onClick={handleToggle}
+                />
+                <div className="h-full border-r border-gray-500"></div>
+              </>
+            )}
+            <li className="inline-flex items-center">
+              <Link
+                href="/"
+                className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+              >
+                <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path>
                 </svg>
-                <Link
-                  href={`/material`}
-                  className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
-                >
-                  Material
-                </Link>
-                {showNavDiagram && itemHovered === "theme" && (
-                  <ThemeCardsPopover
-                    material={material}
-                    excludes={excludes}
-                    onMouseEnter={handlePopoverHovered}
-                    onMouseLeave={handlePopoverNotHovered}
-                    target={ref1?.current || undefined}
-                  />
-                )}
-              </div>
+                Home
+              </Link>
             </li>
-          )}
-          {theme && (
-            <li ref={ref2} onMouseEnter={() => handleIsHovered("course")} onMouseLeave={handleIsNotHovered}>
-              <div className="flex items-center">
-                <svg
-                  className="w-6 h-6 text-gray-400"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    className={showNavDiagram && itemHovered === "course" ? "expanded" : "collapsed"}
-                    style={{ transformOrigin: "50% 50%" }}
-                    fillRule="evenodd"
-                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                    clipRule="evenodd"
-                  ></path>
-                </svg>
-                <Link
-                  aria-current={!course ? "page" : undefined}
-                  href={`/material/${theme.repo}/${theme.id}`}
-                  className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
-                >
-                  {theme.name}
-                </Link>
-                {showNavDiagram && itemHovered === "course" && (
-                  <NavDiagramPopover
-                    material={material}
-                    theme={theme}
-                    excludes={excludes}
-                    target={ref2?.current || undefined}
-                    onMouseEnter={handlePopoverHovered}
-                    onMouseLeave={handlePopoverNotHovered}
-                  />
-                )}
-              </div>
-            </li>
-          )}{" "}
-          {theme && course && (
-            <li ref={ref3} onMouseEnter={() => handleIsHovered("section")} onMouseLeave={handleIsNotHovered}>
-              <div className="flex items-center">
-                <svg
-                  className="w-6 h-6 text-gray-400"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    className={showNavDiagram && itemHovered === "section" ? "expanded" : "collapsed"}
-                    style={{ transformOrigin: "50% 50%" }}
-                    fillRule="evenodd"
-                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                    clipRule="evenodd"
-                  ></path>
-                </svg>
-                <Link
-                  aria-current={!section ? "page" : undefined}
-                  href={`/material/${theme.repo}/${theme.id}/${course.id}`}
-                  className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
-                >
-                  {course.name}
-                </Link>
-                {showNavDiagram && itemHovered === "section" && (
-                  <NavDiagramPopover
-                    material={material}
-                    theme={theme}
-                    course={course}
-                    excludes={excludes}
-                    target={ref3?.current || undefined}
-                    onMouseEnter={handlePopoverHovered}
-                    onMouseLeave={handlePopoverNotHovered}
-                  />
-                )}
-              </div>
-            </li>
-          )}{" "}
-          {section && (
-            <li aria-current="page">
-              <div className="flex items-center">
-                <svg
-                  className="w-6 h-6 text-gray-400"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                    clipRule="evenodd"
-                  ></path>
-                </svg>
-                <span className="ml-1 text-sm font-medium text-gray-500 md:ml-2 dark:text-gray-400">
-                  {section.name}
-                </span>
-              </div>
-            </li>
-          )}
-        </ol>
-      </nav>) : <p>Too small</p>}
+            {theme && (
+              <li ref={ref1} onMouseEnter={() => handleIsHovered("theme")} onMouseLeave={handleIsNotHovered}>
+                <div className="flex items-center">
+                  <svg
+                    className="w-6 h-6 text-gray-400"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      className={showNavDiagram && itemHovered === "theme" ? "expanded" : "collapsed"}
+                      style={{ transformOrigin: "50% 50%" }}
+                      fillRule="evenodd"
+                      d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                      clipRule="evenodd"
+                    ></path>
+                  </svg>
+                  <Link
+                    href={`/material`}
+                    className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
+                  >
+                    Material
+                  </Link>
+                  {showNavDiagram && itemHovered === "theme" && (
+                    <ThemeCardsPopover
+                      material={material}
+                      excludes={excludes}
+                      onMouseEnter={handlePopoverHovered}
+                      onMouseLeave={handlePopoverNotHovered}
+                      target={ref1?.current || undefined}
+                    />
+                  )}
+                </div>
+              </li>
+            )}
+            {theme && (
+              <li ref={ref2} onMouseEnter={() => handleIsHovered("course")} onMouseLeave={handleIsNotHovered}>
+                <div className="flex items-center">
+                  <svg
+                    className="w-6 h-6 text-gray-400"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      className={showNavDiagram && itemHovered === "course" ? "expanded" : "collapsed"}
+                      style={{ transformOrigin: "50% 50%" }}
+                      fillRule="evenodd"
+                      d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                      clipRule="evenodd"
+                    ></path>
+                  </svg>
+                  <Link
+                    aria-current={!course ? "page" : undefined}
+                    href={`/material/${theme.repo}/${theme.id}`}
+                    className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
+                  >
+                    {theme.name}
+                  </Link>
+                  {showNavDiagram && itemHovered === "course" && (
+                    <NavDiagramPopover
+                      material={material}
+                      theme={theme}
+                      excludes={excludes}
+                      target={ref2?.current || undefined}
+                      onMouseEnter={handlePopoverHovered}
+                      onMouseLeave={handlePopoverNotHovered}
+                    />
+                  )}
+                </div>
+              </li>
+            )}{" "}
+            {theme && course && (
+              <li ref={ref3} onMouseEnter={() => handleIsHovered("section")} onMouseLeave={handleIsNotHovered}>
+                <div className="flex items-center">
+                  <svg
+                    className="w-6 h-6 text-gray-400"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      className={showNavDiagram && itemHovered === "section" ? "expanded" : "collapsed"}
+                      style={{ transformOrigin: "50% 50%" }}
+                      fillRule="evenodd"
+                      d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                      clipRule="evenodd"
+                    ></path>
+                  </svg>
+                  <Link
+                    aria-current={!section ? "page" : undefined}
+                    href={`/material/${theme.repo}/${theme.id}/${course.id}`}
+                    className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
+                  >
+                    {course.name}
+                  </Link>
+                  {showNavDiagram && itemHovered === "section" && (
+                    <NavDiagramPopover
+                      material={material}
+                      theme={theme}
+                      course={course}
+                      excludes={excludes}
+                      target={ref3?.current || undefined}
+                      onMouseEnter={handlePopoverHovered}
+                      onMouseLeave={handlePopoverNotHovered}
+                    />
+                  )}
+                </div>
+              </li>
+            )}{" "}
+            {section && (
+              <li aria-current="page">
+                <div className="flex items-center">
+                  <svg
+                    className="w-6 h-6 text-gray-400"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                      clipRule="evenodd"
+                    ></path>
+                  </svg>
+                  <span className="ml-1 text-sm font-medium text-gray-500 md:ml-2 dark:text-gray-400">
+                    {section.name}
+                  </span>
+                </div>
+              </li>
+            )}
+          </ol>
+        </nav>
+      ) : (
+        <IconButton size="large" edge="start" color="inherit" aria-label="menu" className="text-gray-400"sx={{ mr: 2 }}>
+          <MenuIcon />
+        </IconButton>
+      )}
       <ul aria-label="Page tools" className="gap-1 relative flex list-none items-center">
         {theme && course && section && (
           <li className="inline-flex">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -11,7 +11,7 @@ import { useRecoilState } from "recoil"
 import { enableSearch } from "lib/search/enableSearch"
 import NavDiagramPopover from "./dialogs/navDiagramPop"
 import ThemeCardsPopover from "./dialogs/themeCardPop"
-import { IconButton } from "@mui/material"
+import { Divider, IconButton } from "@mui/material"
 import MenuIcon from "@mui/icons-material/Menu"
 import Drawer from "@mui/material/Drawer"
 import CloseIcon from "@mui/icons-material/Close"
@@ -55,6 +55,7 @@ const Navbar: React.FC<Props> = ({
   const [drawerOpen, setDrawerOpen] = useState(false)
   const windowSize = useWindowSize()
   const breakpoint = 900
+  const burgerDrawerMaterialMargin = "ml-3"
   const { data: session } = useSession()
   const ref1 = useRef<HTMLLIElement>(null)
   const ref2 = useRef<HTMLLIElement>(null)
@@ -305,7 +306,7 @@ const Navbar: React.FC<Props> = ({
               <IconButton onClick={() => toggleDrawer(false)} sx={{ p: 2 }}>
                 <CloseIcon />
               </IconButton>
-              <ol className="p-5 flex flex-col gap-2">
+              <ol className="p-5 flex flex-col gap-3">
                 <li className="inline-flex items-center">
                   <Link
                     href="/"
@@ -323,17 +324,22 @@ const Navbar: React.FC<Props> = ({
                   </Link>
                 </li>
                 {theme && (
-                  <li>
-                    <div className="flex items-center">
-                      <Link
-                        href={`/material`}
-                        className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-                      >
-                        
-                      Material
-                      </Link>
-                    </div>
-                  </li>
+                  <ol>
+                    <li>
+                      <div className="flex items-center">
+                        <Link
+                          href={`/material`}
+                          className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                        >
+                    
+                        <span className="pb-2">Material</span>
+                    
+                        </Link>
+                    
+                      </div>
+                    </li>
+                    <li><Divider variant="fullWidth" /></li>
+                  </ol>
                 )}
                 {theme && (
                   <li ref={ref2} onMouseEnter={() => handleIsHovered("course")} onMouseLeave={handleIsNotHovered}>
@@ -341,7 +347,7 @@ const Navbar: React.FC<Props> = ({
                       <Link
                         aria-current={!course ? "page" : undefined}
                         href={`/material/${theme.repo}/${theme.id}`}
-                        className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
+                        className={`${burgerDrawerMaterialMargin} text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white`}
                       >
                         {theme.name}
                       </Link>
@@ -354,7 +360,7 @@ const Navbar: React.FC<Props> = ({
                       <Link
                         aria-current={!section ? "page" : undefined}
                         href={`/material/${theme.repo}/${theme.id}/${course.id}`}
-                        className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
+                        className={`${burgerDrawerMaterialMargin} text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white`}
                       >
                         {course.name}
                       </Link>
@@ -364,7 +370,7 @@ const Navbar: React.FC<Props> = ({
                 {section && (
                   <li aria-current="page">
                     <div className="flex items-center">
-                      <span className="ml-1 text-sm font-medium text-gray-500 md:ml-2 dark:text-gray-400">
+                      <span className={`${burgerDrawerMaterialMargin} text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white`}>
                         {section.name}
                       </span>
                     </div>
@@ -375,7 +381,7 @@ const Navbar: React.FC<Props> = ({
           </Drawer>
         </div>
       )}
-      <ul aria-label="Page tools" className="gap-1 relative flex list-none items-center">
+      <ul aria-label="Page tools" className="gap-2 relative flex list-none items-center">
         {theme && course && section && (
           <li className="inline-flex">
             <Link

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -14,7 +14,7 @@ import ThemeCardsPopover from "./dialogs/themeCardPop"
 import { IconButton } from "@mui/material"
 import MenuIcon from "@mui/icons-material/Menu"
 import Drawer from "@mui/material/Drawer"
-import CloseIcon from "@mui/icons-material/Close";
+import CloseIcon from "@mui/icons-material/Close"
 import Box from "@mui/material/Box"
 import useWindowSize from "lib/hooks/useWindowSize"
 
@@ -301,10 +301,75 @@ const Navbar: React.FC<Props> = ({
             <MenuIcon />
           </IconButton>
           <Drawer open={drawerOpen}>
-            <Box  sx={{width: 250}}>
-            <IconButton onClick={() => toggleDrawer(false)} sx={{ p: 2 }}>
+            <Box sx={{ width: 250 }}>
+              <IconButton onClick={() => toggleDrawer(false)} sx={{ p: 2 }}>
                 <CloseIcon />
               </IconButton>
+              <ol className="p-5 flex-col">
+                <li className="inline-flex items-center">
+                  <Link
+                    href="/"
+                    className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                  >
+                    <svg
+                      className="w-4 h-4 mr-2"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path>
+                    </svg>
+                    Home
+                  </Link>
+                </li>
+                {theme && (
+                  <li>
+                    <div className="flex items-center">
+                      <Link
+                        href={`/material`}
+                        className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
+                      >
+                        Material
+                      </Link>
+                    </div>
+                  </li>
+                )}
+                {theme && (
+                  <li ref={ref2} onMouseEnter={() => handleIsHovered("course")} onMouseLeave={handleIsNotHovered}>
+                    <div className="flex items-center">
+                      <Link
+                        aria-current={!course ? "page" : undefined}
+                        href={`/material/${theme.repo}/${theme.id}`}
+                        className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
+                      >
+                        {theme.name}
+                      </Link>
+                    </div>
+                  </li>
+                )}{" "}
+                {theme && course && (
+                  <li>
+                    <div className="flex items-center">
+                      <Link
+                        aria-current={!section ? "page" : undefined}
+                        href={`/material/${theme.repo}/${theme.id}/${course.id}`}
+                        className="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2 dark:text-gray-400 dark:hover:text-white"
+                      >
+                        {course.name}
+                      </Link>
+                    </div>
+                  </li>
+                )}{" "}
+                {section && (
+                  <li aria-current="page">
+                    <div className="flex items-center">
+                      <span className="ml-1 text-sm font-medium text-gray-500 md:ml-2 dark:text-gray-400">
+                        {section.name}
+                      </span>
+                    </div>
+                  </li>
+                )}
+              </ol>
             </Box>
           </Drawer>
         </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -115,8 +115,8 @@ const Navbar: React.FC<Props> = ({
 
   return (
     // remove width !
-    <div className="z-10 flex p-2 mx-2 mt-2 mb-4 text-gray-700 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
-      {windowSize.width}
+    <div className="z-10 flex p-2 mx-2 mt-2 mb-4 text-gray-700 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700 justify-between">
+      {/* {windowSize.width} */}
       {(windowSize.width ?? 1024) >= 1024 ?  (
         <nav className="w-full inline-flex" aria-label="Breadcrumb">
           <ol className="z-10 list-none inline-flex items-center space-x-1 md:space-x-3">
@@ -274,11 +274,11 @@ const Navbar: React.FC<Props> = ({
           </ol>
         </nav>
       ) : (
-        <IconButton size="large" edge="start" color="inherit" aria-label="menu" className="text-gray-400"sx={{ mr: 2 }}>
+        <IconButton size="large" edge="start" color="inherit" aria-label="menu" className="text-gray-400 px-5"sx={{ mr: 2 }}>
           <MenuIcon />
         </IconButton>
       )}
-      <ul aria-label="Page tools" className="gap-1 relative flex list-none items-center justify-end">
+      <ul aria-label="Page tools" className="gap-1 relative flex list-none items-center">
         {theme && course && section && (
           <li className="inline-flex">
             <Link

--- a/components/ThemeCards.tsx
+++ b/components/ThemeCards.tsx
@@ -1,6 +1,7 @@
 import { Material, Excludes } from "lib/material"
 import { basePath } from "lib/basePath"
 import { Card } from "flowbite-react"
+import useWindowSize from "lib/hooks/useWindowSize"
 
 interface Props {
   material: Material
@@ -9,7 +10,9 @@ interface Props {
 }
 
 const ThemeCards = ({ material, excludes, includeSummary = true }: Props) => {
-  const numberCols = includeSummary ? 2 : 1
+  const windowSize = useWindowSize()
+  const columnBreakpoint = 550
+  const numberCols = includeSummary && (windowSize.width ?? 1024) > columnBreakpoint ? 2 : 1
   const textSize = includeSummary ? "text-2xl" : "text-md"
   const themeCards = material?.themes
     .filter((theme) => !excludes || !excludes.themes.includes(theme.id))

--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -149,7 +149,7 @@ const Content: React.FC<Props> = ({ markdown, theme, course, section }) => {
     section ? section.id : ""
   }`
   return (
-    <div className="mx-auto prose prose-base max-w-2xl prose-slate dark:prose-invert prose-pre:bg-[#263E52] prose-pre:p-0">
+    <div className="mx-auto prose prose-base max-w-2xl prose-slate dark:prose-invert prose-pre:bg-[#263E52] px-5">
       <ReactMarkdown
         remarkPlugins={[directive, reactMarkdownRemarkDirective, remarkMath, remarkGfm]}
         rehypePlugins={[rehypeKatex]}

--- a/components/ui/ThemeSwitcher.tsx
+++ b/components/ui/ThemeSwitcher.tsx
@@ -11,7 +11,7 @@ export const ThemeButton = () => {
     <button
       aria-label="Toggle theme"
       onClick={() => (theme == "dark" ? setTheme("light") : setTheme("dark"))}
-      className="bg-gray-800 dark:bg-gray-50 hover:bg-gray-600 dark:hover:bg-gray-300 transition-all duration-100 text-white rounded dark:text-gray-800 px-2 py-2"
+      className="bg-gray-800 dark:bg-gray-50 hover:bg-gray-600 dark:hover:bg-gray-300 transition-all duration-100 text-white rounded dark:text-gray-800 px-2 py-2 h-full"
     >
       {icon}
     </button>

--- a/pages/material/index.tsx
+++ b/pages/material/index.tsx
@@ -17,7 +17,7 @@ type HomeProps = {
 const Home: NextPage<HomeProps> = ({ material, events, pageInfo }) => {
   return (
     <Layout material={material} pageInfo={pageInfo}>
-      <h1 className="text-3xl font-bold text-center">Material Themes</h1>
+      <h1 className="text-3xl font-bold text-center p-3">Material Themes</h1>
       <ThemeCards material={material} />
     </Layout>
   )


### PR DESCRIPTION
A few questions about a few proposed changes to improve UI at mobile and narrow-desktop resolutions. Breaking down changes in each file:

### Navbar.tsx

Presents navbar as burger menu at narrow resolutions. A few things:

- At the moment I have implemented this with a ternary operator using the useWindowSize hook, returning a different navbar beyond the breakpoint. This works but adds loads of lines to the file so readability isn't great. Should I separate the standard and narrow versions into new components? e.g.

`{(windowSize.width ?? 1024) >= 1024 ? <NavbarWide /> : <NavbarBurger />`

- Open to suggestions here
- The burger menu drawer is currently quite minimally styled, any ideas for this? I could add the same arrows as the wide navbar but going down vertically?

**Current:**

![Screenshot 2024-07-03 at 12 41 03](https://github.com/OxfordRSE/gutenberg/assets/10367135/1948be69-7d72-4570-a8e3-881c9e1e28b0)

**Proposed:**

![Screenshot 2024-07-03 at 12 41 50](https://github.com/OxfordRSE/gutenberg/assets/10367135/3f1b9894-c901-4b57-ba04-b22678ca2985)

![Screenshot 2024-07-03 at 12 42 11](https://github.com/OxfordRSE/gutenberg/assets/10367135/82d6206e-3a3a-4776-86ae-5e5b02c05700)


### Footer.tsx & ThemeSwitcher.tsx

Improves positioning within the footer when it condenses.

**Current**:

![Screenshot 2024-07-03 at 12 38 10](https://github.com/OxfordRSE/gutenberg/assets/10367135/a6cd9446-b8ec-4a85-a262-8c8ee4fab20d)

**Proposed:**

![Screenshot 2024-07-03 at 12 39 13](https://github.com/OxfordRSE/gutenberg/assets/10367135/ea584738-877e-4e49-9986-4d4663d6660f)

### ThemeCards.tsx & /material/index.tsx

- Positions material theme cards into one column below a breakpoint.
- Adds padding to 'Material Themes' title, looked a little too condensed

**Current:**

![Screenshot 2024-07-03 at 13 00 18](https://github.com/OxfordRSE/gutenberg/assets/10367135/09af647f-ac44-4f18-a162-c8c3a78faf32)

**Proposed:**

![Screenshot 2024-07-03 at 13 00 50](https://github.com/OxfordRSE/gutenberg/assets/10367135/ece6687c-687e-41fc-9c35-2f9f23533599)

### Content.tsx

Adds padding to content

**Current:**
![Screenshot 2024-07-03 at 13 05 33](https://github.com/OxfordRSE/gutenberg/assets/10367135/75576720-8d84-43f9-9496-cffb0bc9abe8)

**Proposed:**

![Screenshot 2024-07-03 at 13 06 47](https://github.com/OxfordRSE/gutenberg/assets/10367135/ebd2ecc5-8532-453b-8732-9d82a35a4b92)


