### PR TITLE
Prev next buttons

### DIFF
--- a/components/ui/LinkedSection.tsx
+++ b/components/ui/LinkedSection.tsx
@@ -63,7 +63,7 @@ export const LinkedSection = (sectionLink: SectionLink) => {
     <Tooltip title={tooltipTitle}>
       <a href={`${sectionLink.url}`} className={`pointer-events-auto text-gray-600 hover:text-gray-500 opacity-50`}>
         <div
-          className={`group rounded-md border-2 hover:border-4 ${borderColor} ${calcAnchorHeight} w-[150px] text-sm`}
+          className={`group rounded-md border-2 hover:border-4 hover:-mt-1 ${borderColor} ${calcAnchorHeight} w-[150px] text-sm`}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >

--- a/components/ui/LinkedSection.tsx
+++ b/components/ui/LinkedSection.tsx
@@ -72,7 +72,7 @@ export const LinkedSection = (sectionLink: SectionLink) => {
             <div>
               {sectionLink.theme && (
                 <p className="text-slate-500 dark:text-slate-200 text-xs font-medium">
-                  {trimString(sectionLink.theme, 21)}
+                  {trimString(sectionLink.theme, 35)}
                 </p>
               )}
               {sectionLink.course && (


### PR DESCRIPTION
Just a small one - fixes #234 (I think) - turned out to be quite simple. I also changed the clip length of the theme text from 21 to 35 ('Technology and Tooling' below), seems to work fine with the anchor height changing dynamically.

I could also very easily add some padding between vertically stacked buttons if desired 

Current:
![Current](https://github.com/OxfordRSE/gutenberg/assets/10367135/dcb2bd45-b8cb-4425-ad22-d8e74a553ab7)

Proposed:
![Proposed](https://github.com/OxfordRSE/gutenberg/assets/10367135/393eff57-ff55-4110-9e30-e5f76ac2dfda)
