### PR TITLE
fix(a11y): wrap course grids in nav landmarks

### DIFF
--- a/components/navdiagram/CourseGrid.tsx
+++ b/components/navdiagram/CourseGrid.tsx
@@ -48,62 +48,64 @@ function CourseGrid({ course, theme }: { course: Course; theme: Theme }) {
                   <Typography variant="h6">{commonTag.toUpperCase()}</Typography>
                 </Box>
               )}
-              <Grid container spacing={0}>
-                {column.map((file, rowIndex) => {
-                  const section = findSectionByName(file)
-                  if (!section) return null
-                  const url = `/material/${repo}/${course.theme}/${course.id}/${section.id}`
+              <nav aria-label={commonTag || undefined}>
+                <Grid component="ul" container spacing={0}>
+                  {column.map((file, rowIndex) => {
+                    const section = findSectionByName(file)
+                    if (!section) return null
+                    const url = `/material/${repo}/${course.theme}/${course.id}/${section.id}`
 
-                  // Determine if this is the first or last item
-                  const isFirstItem = rowIndex === 0 && !commonTag
-                  const isLastItem = rowIndex === column.length - 1
+                    // Determine if this is the first or last item
+                    const isFirstItem = rowIndex === 0 && !commonTag
+                    const isLastItem = rowIndex === column.length - 1
 
-                  return (
-                    <Grid item xs={12} key={rowIndex}>
-                      <Link href={url}>
-                        <Paper
-                          elevation={3}
-                          sx={{
-                            borderRadius: isFirstItem ? "8px 8px 0 0" : isLastItem ? "0 0 8px 8px" : "0px",
-                            p: 2,
-                            textAlign: "center",
-                          }}
-                        >
-                          <Box
+                    return (
+                      <Grid component="li" item xs={12} key={rowIndex}>
+                        <Link href={url}>
+                          <Paper
+                            elevation={3}
                             sx={{
-                              width: "100%",
-                              display: "flex",
-                              justifyContent: "space-between",
-                              alignItems: "center",
+                              borderRadius: isFirstItem ? "8px 8px 0 0" : isLastItem ? "0 0 8px 8px" : "0px",
+                              p: 2,
+                              textAlign: "center",
                             }}
                           >
-                            <Typography variant="body1" sx={{ flex: "1", textAlign: "left" }}>
-                              {section.name}
-                            </Typography>
-                            <Box sx={{ display: "flex", gap: 0.5 }}>
-                              {section.tags.map((tag) => {
-                                // If the tag doesn't have a color yet, assign it one
-                                if (!tagColorMap[tag]) {
-                                  tagColorMap[tag] = chipColors[tagColorIndex % chipColors.length]
-                                  tagColorIndex++
-                                }
-                                return (
-                                  <Chip
-                                    key={tag}
-                                    label={tag}
-                                    size="small"
-                                    sx={{ backgroundColor: tagColorMap[tag], fontSize: "0.75rem", height: "20px" }}
-                                  />
-                                )
-                              })}
+                            <Box
+                              sx={{
+                                width: "100%",
+                                display: "flex",
+                                justifyContent: "space-between",
+                                alignItems: "center",
+                              }}
+                            >
+                              <Typography variant="body1" sx={{ flex: "1", textAlign: "left" }}>
+                                {section.name}
+                              </Typography>
+                              <Box sx={{ display: "flex", gap: 0.5 }}>
+                                {section.tags.map((tag) => {
+                                  // If the tag doesn't have a color yet, assign it one
+                                  if (!tagColorMap[tag]) {
+                                    tagColorMap[tag] = chipColors[tagColorIndex % chipColors.length]
+                                    tagColorIndex++
+                                  }
+                                  return (
+                                    <Chip
+                                      key={tag}
+                                      label={tag}
+                                      size="small"
+                                      sx={{ backgroundColor: tagColorMap[tag], fontSize: "0.75rem", height: "20px" }}
+                                    />
+                                  )
+                                })}
+                              </Box>
                             </Box>
-                          </Box>
-                        </Paper>
-                      </Link>
-                    </Grid>
-                  )
-                })}
-              </Grid>
+                          </Paper>
+                        </Link>
+                      </Grid>
+                    )
+                  })}
+                </Grid>
+              </nav>
             </Grid>
           )
         })}


### PR DESCRIPTION
Wrap each column of a course grid in `<nav>`, rather than `<div>`. Label the navigation with the grid heading tag, if one is defined. Markup the list of links as an unordered list.