### PR TITLE
refactor: equal height theme cards

### DIFF
--- a/components/navdiagram/ThemeGrid.tsx
+++ b/components/navdiagram/ThemeGrid.tsx
@@ -14,7 +14,7 @@ function ThemeGrid({ theme }: { theme: Theme }) {
           return (
             <Grid item xs={Math.max(12 / courses.length, 4)} key={colIndex}>
               <Link href={`/material/${repo}/${theme.id}/${course.id}`}>
-                <Paper elevation={3} sx={{ p: 2, textAlign: "center" }}>
+                <Paper elevation={3} sx={{ p: 2, textAlign: "center", height: "100%" }}>
                   <Typography variant="h5" component="h2">
                     {course ? course.name : "Unnamed Section"}
                   </Typography>


### PR DESCRIPTION
Set the theme card height to 100%, so that heights match along a row.

Before:

<img width="800" alt="High Performance Computing theme cards with different heights across each row." src="https://github.com/user-attachments/assets/b4c0ce6e-0ebf-407c-b68c-a4dfdc546799">

After:

<img width="1181" alt="High Performance Computing theme cards with matching heights across each row." src="https://github.com/user-attachments/assets/72eef7f4-8cfb-4386-924f-62e658ab4a99">
