### PR TITLE
fix(a11y): turn off React Flow keyboard focus behaviour

### DIFF
--- a/components/navdiagram/NavDiagram.tsx
+++ b/components/navdiagram/NavDiagram.tsx
@@ -441,6 +441,9 @@ const NavDiagram: React.FC<NavDiagramProps> = ({ material, theme, course, exclud
           maxZoom={2}
           fitView
           fitViewOptions={fitViewOptions}
+          edgesFocusable={false}
+          nodesFocusable={false}
+          nodesDraggable={false}
         ></ReactFlow>
       </div>
     </div>


### PR DESCRIPTION
Turn off draggable/focus behaviour for React Flow nodes and edges. This should make the course diagrams easier to use when navigating the page with the keyboard.