### PR TITLE
Heading anchor links

### DIFF
--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -20,7 +20,7 @@ import Solution from "./Solution"
 import { first } from "cypress/types/lodash"
 import remarkDirective from "remark-directive"
 import remarkDirectiveRehype from "remark-directive-rehype"
-import { CodeComponent, CodeProps, ReactMarkdownProps } from "react-markdown/lib/ast-to-react"
+import { CodeComponent, CodeProps, HeadingProps, ReactMarkdownProps } from "react-markdown/lib/ast-to-react"
 import Callout from "../Callout"
 import { Course, Section, Theme } from "lib/material"
 import Paragraph from "./Paragraph"
@@ -58,7 +58,7 @@ const list = (sectionStr: string) => {
 }
 
 const h = (sectionStr: string, tag: string) => {
-  function h({ node, children, ...props }: ReactMarkdownProps) {
+  function h({ node, children, ...props }: HeadingProps) {
     return <Heading content={children} section={sectionStr} tag={tag} />
   }
   return h

--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -24,6 +24,7 @@ import { CodeComponent, CodeProps, ReactMarkdownProps } from "react-markdown/lib
 import Callout from "../Callout"
 import { Course, Section, Theme } from "lib/material"
 import Paragraph from "./Paragraph"
+import Heading from "./Heading"
 
 function reactMarkdownRemarkDirective() {
   return (tree: any) => {
@@ -54,6 +55,13 @@ const list = (sectionStr: string) => {
     )
   }
   return list
+}
+
+const h = (sectionStr: string, tag: string) => {
+  function h({ node, children, ...props }: ReactMarkdownProps) {
+    return <Heading content={children} section={sectionStr} tag={tag} />
+  }
+  return h
 }
 
 let solutionCount = 0
@@ -161,6 +169,9 @@ const Content: React.FC<Props> = ({ markdown, theme, course, section }) => {
           code,
           p: p(sectionStr),
           li: list(sectionStr),
+          h2: h(sectionStr, "h2"),
+          h3: h(sectionStr, "h3"),
+          h4: h(sectionStr, "h4"),
         }}
       >
         {markdown}

--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import CopyToClipboard from "react-copy-to-clipboard"
 import { FaLink } from "react-icons/fa"
 
@@ -11,6 +11,7 @@ interface HeadingProps {
 const Heading: React.FC<HeadingProps> = ({ content, section, tag = "p" }) => {
   const Tag = tag as keyof JSX.IntrinsicElements
   const headingContent = content?.toString().replaceAll(" ", "-")
+  const [isCopied, setIsCopied] = useState(false)
 
   const generateHeadingURL = () => {
     const href: string = typeof window !== "undefined" ? window.location.href.split("#")[0] : ""
@@ -18,7 +19,10 @@ const Heading: React.FC<HeadingProps> = ({ content, section, tag = "p" }) => {
   }
 
   const onCopyHandler = () => {
-    return
+    setIsCopied(true)
+    setTimeout(() => {
+      setIsCopied(false)
+    }, 1500)
   }
 
   return (
@@ -30,6 +34,7 @@ const Heading: React.FC<HeadingProps> = ({ content, section, tag = "p" }) => {
             <FaLink className="group-hover:text-white" />
           </button>
         </CopyToClipboard>
+        {isCopied && <span className="text-xs text-green-500 flex items-center">Copied to clipboard!</span>}
       </Tag>
     </>
   )

--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -1,4 +1,6 @@
 import React from "react"
+import CopyToClipboard from "react-copy-to-clipboard"
+import { FaLink } from "react-icons/fa"
 
 interface HeadingProps {
   content: React.ReactNode
@@ -15,9 +17,20 @@ const Heading: React.FC<HeadingProps> = ({ content, section, tag = "p" }) => {
     return href + "#" + headingContent ?? ""
   }
 
+  const onCopyHandler = () => {
+    return
+  }
+
   return (
     <>
-      <Tag id={headingContent}>{content}</Tag>
+      <Tag id={headingContent} className="flex gap-3">
+        {content}
+        <CopyToClipboard text={generateHeadingURL()}>
+          <button className="text-xs align-top" onClick={onCopyHandler}>
+            <FaLink className="group-hover:text-white" />
+          </button>
+        </CopyToClipboard>
+      </Tag>
     </>
   )
 }

--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -10,6 +10,11 @@ const Heading: React.FC<HeadingProps> = ({ content, section, tag = "p" }) => {
   const Tag = tag as keyof JSX.IntrinsicElements
   const headingContent = content?.toString().replaceAll(" ", "-")
 
+  const generateHeadingURL = () => {
+    const href: string = typeof window !== "undefined" ? window.location.href.split("#")[0] : ""
+    return href + "#" + headingContent ?? ""
+  }
+
   return (
     <>
       <Tag id={headingContent}>{content}</Tag>

--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -5,10 +5,10 @@ import { FaLink } from "react-icons/fa"
 interface HeadingProps {
   content: React.ReactNode
   section: string
-  tag?: string
+  tag: string
 }
 
-const Heading: React.FC<HeadingProps> = ({ content, section, tag = "p" }) => {
+const Heading: React.FC<HeadingProps> = ({ content, section, tag }) => {
   const Tag = tag as keyof JSX.IntrinsicElements
   const headingContent = content?.toString().replaceAll(" ", "-")
   const [isCopied, setIsCopied] = useState(false)

--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+
+interface HeadingProps {
+  content: React.ReactNode
+  section: string
+  tag?: string
+}
+
+const Heading: React.FC<HeadingProps> = ({ content, section, tag = "p" }) => {
+  const Tag = tag as keyof JSX.IntrinsicElements
+  const headingContent = content?.toString().replaceAll(" ", "-")
+
+  return (
+    <>
+      <Tag id={headingContent}>{content}</Tag>
+    </>
+  )
+}
+
+export default Heading


### PR DESCRIPTION
Revised PR #237, commit history was a bit messy so a new branch seems easier - made a separate heading component and changed the copy to clipboard button, fixes #192 . Anything that you'd like to be changed about this?

![Clipboard](https://github.com/user-attachments/assets/08468d85-acdb-420a-a750-fcc1707f4fcf)

This now doesn't fix commenting on headings - should probably be addressed in another PR if still wanted. A lot of the comment and thread logic seems to be in the paragraph component and I wasn't sure how best to implement this in another component - #231 is marked as a regression so maybe this has already been considered?
