### PR TITLE
Fix code headings

### DIFF
--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -42,14 +42,14 @@ const Heading: React.FC<HeadingProps> = ({ content, section, tag }) => {
 
   return (
     <>
-      <Tag id={generateHeadingContent()} className="flex gap-3">
+      <Tag id={generateHeadingContent()}>
         {content}
         <CopyToClipboard text={generateHeadingURL()}>
-          <button className="text-xs align-top" onClick={onCopyHandler}>
-            <FaLink className="group-hover:text-white" />
+          <button className="text-xs align-center" onClick={onCopyHandler}>
+            <FaLink className="group-hover:text-white ml-3" />
           </button>
         </CopyToClipboard>
-        {isCopied && <span className="text-xs text-green-500 flex items-center">Copied to clipboard!</span>}
+        {isCopied && <span className="text-xs text-green-500 items-center ml-3">Copied to clipboard!</span>}
       </Tag>
     </>
   )

--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -10,12 +10,27 @@ interface HeadingProps {
 
 const Heading: React.FC<HeadingProps> = ({ content, section, tag }) => {
   const Tag = tag as keyof JSX.IntrinsicElements
-  const headingContent = content?.toString().replaceAll(" ", "-")
+  const headingContent = content?.toString().replace(/#/g, "").trim().replace(/ /g, "-").replace(/:/g, "").replace(/`/g, "")
   const [isCopied, setIsCopied] = useState(false)
 
+  const generateHeadingContent = () => {
+    let headingContent = ''
+    if (typeof content === 'object') {
+      for (let key in content) {
+        if (typeof (content as any)[key] === 'object') {
+          headingContent += (content as any)[key].props.children  
+        } else {
+          headingContent += (content as any)[key]
+        }
+    }
+    return headingContent.replace(/#/g, "").trim().replace(/ /g, "-").replace(/:/g, "").replace(/`/g, "")
+  }}
+
+
   const generateHeadingURL = () => {
+    console.log(generateHeadingContent())
     const href: string = typeof window !== "undefined" ? window.location.href.split("#")[0] : ""
-    return href + "#" + headingContent ?? ""
+    return href + "#" + generateHeadingContent() ?? ""
   }
 
   const onCopyHandler = () => {
@@ -27,7 +42,7 @@ const Heading: React.FC<HeadingProps> = ({ content, section, tag }) => {
 
   return (
     <>
-      <Tag id={headingContent} className="flex gap-3">
+      <Tag id={generateHeadingContent()} className="flex gap-3">
         {content}
         <CopyToClipboard text={generateHeadingURL()}>
           <button className="text-xs align-top" onClick={onCopyHandler}>

--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -13,18 +13,18 @@ const Heading: React.FC<HeadingProps> = ({ content, section, tag }) => {
   const [isCopied, setIsCopied] = useState(false)
 
   const generateHeadingContent = () => {
-    let headingContent = ''
-    if (typeof content === 'object') {
+    let headingContent = ""
+    if (typeof content === "object") {
       for (let key in content) {
-        if (typeof (content as any)[key] === 'object') {
-          headingContent += (content as any)[key].props.children  
+        if (typeof (content as any)[key] === "object") {
+          headingContent += (content as any)[key].props.children
         } else {
           headingContent += (content as any)[key]
         }
+      }
+      return headingContent.replace(/#/g, "").trim().replace(/ /g, "-").replace(/:/g, "").replace(/`/g, "")
     }
-    return headingContent.replace(/#/g, "").trim().replace(/ /g, "-").replace(/:/g, "").replace(/`/g, "")
-  }}
-
+  }
 
   const generateHeadingURL = () => {
     const href: string = typeof window !== "undefined" ? window.location.href.split("#")[0] : ""

--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -27,7 +27,6 @@ const Heading: React.FC<HeadingProps> = ({ content, section, tag }) => {
 
 
   const generateHeadingURL = () => {
-    console.log(generateHeadingContent())
     const href: string = typeof window !== "undefined" ? window.location.href.split("#")[0] : ""
     return href + "#" + generateHeadingContent() ?? ""
   }

--- a/components/content/Heading.tsx
+++ b/components/content/Heading.tsx
@@ -10,7 +10,6 @@ interface HeadingProps {
 
 const Heading: React.FC<HeadingProps> = ({ content, section, tag }) => {
   const Tag = tag as keyof JSX.IntrinsicElements
-  const headingContent = content?.toString().replace(/#/g, "").trim().replace(/ /g, "-").replace(/:/g, "").replace(/`/g, "")
   const [isCopied, setIsCopied] = useState(false)
 
   const generateHeadingContent = () => {


### PR DESCRIPTION
Fixes heading id and anchor links from displaying incorrectly when they have code blocks in the title and improves how they are displayed. Also now uses the same anchor formatting as extractTitleAndAnchor in splitMarkdown.ts from the returned search url