### PR TITLE
New user comment table on event page

### DIFF
--- a/components/EventCommentThreads.tsx
+++ b/components/EventCommentThreads.tsx
@@ -1,8 +1,50 @@
-import React from "react"
+import React, { useState, useEffect, useMemo } from "react"
 import { Material, sectionSplit } from "lib/material"
 import { EventFull } from "lib/types"
+import { Avatar } from "flowbite-react"
 import Link from "next/link"
 import useCommentThreads from "lib/hooks/useCommentThreads"
+import { useTheme } from "next-themes"
+import useUsersList from "lib/hooks/useUsersList"
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from "@mui/material"
+import Stack from "./ui/Stack"
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
+import ExpandLessIcon from "@mui/icons-material/ExpandLess"
+import { CommentThread } from "pages/api/commentThread/[commentThreadId]"
+
+const noSectionKey = "No Section found (material changed?)"
+
+// group threads by section
+const groupThreadsBySection = (threads: CommentThread[], material: Material) => {
+  const grouped: { [key: string]: CommentThread[] } = {}
+  threads.forEach((thread: CommentThread) => {
+    const { section } = sectionSplit(thread.section, material)
+    if (section && "name" in section) {
+      if (!grouped[section.name]) {
+        grouped[section.name] = []
+      }
+      grouped[section.name].push(thread)
+    } else {
+      if (!grouped[noSectionKey]) {
+        grouped[noSectionKey] = []
+      }
+      grouped[noSectionKey].push(thread)
+    }
+  })
+  return grouped
+}
 
 type Props = {
   event: EventFull
@@ -11,26 +53,237 @@ type Props = {
 
 const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
   const { commentThreads, error: threadsError, isLoading: threadsIsLoading } = useCommentThreads(event.id)
-  if (threadsIsLoading) return <div>loading...</div>
-  if (!commentThreads) return <div>failed to load</div>
+  const [expandedSections, setExpandedSections] = useState<{ [key: string]: boolean }>({})
+  const { theme: currentTheme } = useTheme()
+
+  // Memoize the emails array to prevent unnecessary re-renders
+  const emails = useMemo(() => {
+    return commentThreads?.map((thread) => thread.createdByEmail) || []
+  }, [commentThreads])
+
+  const { users, error: usersError } = useUsersList(emails)
+
+  console.log("us", users)
+
+  useEffect(() => {
+    if (commentThreads) {
+      const unresolvedSectionNames = Object.keys(groupedUnresolvedThreads)
+      const resolvedSectionNames = Object.keys(groupedResolvedThreads)
+
+      const initialExpandedState: { [key: string]: boolean } = {}
+
+      unresolvedSectionNames.forEach((sectionName) => {
+        if (sectionName !== noSectionKey) {
+          initialExpandedState[sectionName] = true
+        }
+      })
+
+      resolvedSectionNames.forEach((sectionName) => {
+        initialExpandedState[sectionName] = true
+      })
+
+      // ensure noSectionKey is collapsed
+      initialExpandedState[noSectionKey] = false
+
+      setExpandedSections(initialExpandedState)
+    }
+  }, [commentThreads]) // Only run when commentThreads change
+
+  if (threadsIsLoading) return <div>Loading...</div>
+  if (!commentThreads) return <div>Failed to load</div>
 
   const unresolvedThreads = commentThreads.filter((thread) => !thread.resolved)
+  const resolvedThreads = commentThreads.filter((thread) => thread.resolved)
+
+  const groupedUnresolvedThreads: { [key: string]: typeof unresolvedThreads } = groupThreadsBySection(
+    unresolvedThreads,
+    material
+  )
+  const groupedResolvedThreads: { [key: string]: typeof resolvedThreads } = groupThreadsBySection(
+    resolvedThreads,
+    material
+  )
+
+  const toggleSection = (sectionName: string) => {
+    console.log("toggleSection", sectionName, expandedSections)
+    setExpandedSections((prevState) => ({
+      ...prevState,
+      [sectionName]: !prevState[sectionName],
+    }))
+  }
+
   return (
     <div>
-      <ul className="list-disc text-gray-800 dark:text-gray-300">
-        {unresolvedThreads.map((thread) => {
-          const { theme, course, section, url } = sectionSplit(thread.section, material)
-          const urlWithAnchor = url + `#comment-thread-${thread.id}`
-          return (
-            <li key={thread.id}>
-              <Link href={urlWithAnchor}>
-                <span className="font-bold">{thread.section}:</span> {thread.createdByEmail}:{" "}
-                {thread.Comment.length > 0 ? thread.Comment[0].markdown : ""}
-              </Link>
-            </li>
-          )
-        })}
-      </ul>
+      <Accordion defaultExpanded>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="h6">Unresolved Comment Threads</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <TableContainer component={Paper}>
+            <Table aria-label="unresolved threads table" size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell colSpan={3}>
+                    <Typography variant="body1" fontWeight="bold">
+                      Section
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {Object.keys(groupedUnresolvedThreads).map((sectionName) => {
+                  const isExpanded = expandedSections[sectionName] || false
+                  const firstThread = groupedUnresolvedThreads[sectionName][0]
+                  const { url } = sectionSplit(firstThread.section, material)
+
+                  return (
+                    <React.Fragment key={sectionName}>
+                      <TableRow onClick={() => toggleSection(sectionName)} style={{ cursor: "pointer" }}>
+                        <TableCell
+                          colSpan={3}
+                          sx={{
+                            backgroundColor: (theme) => (theme.palette.mode === "dark" ? "#000000" : "#e5e7eb"),
+                          }}
+                        >
+                          <Typography variant="body1" fontWeight="bold">
+                            {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />} {sectionName}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+
+                      {isExpanded && (
+                        <>
+                          <TableRow>
+                            <TableCell sx={{ width: "25%" }}>
+                              <strong>Created By</strong>
+                            </TableCell>
+                            <TableCell sx={{ width: "75%" }}>
+                              <strong>Comment</strong>
+                            </TableCell>
+                          </TableRow>
+                          {groupedUnresolvedThreads[sectionName].map((thread) => {
+                            const urlWithAnchor = url + `#comment-thread-${thread.id}`
+
+                            const commentText =
+                              thread.Comment &&
+                              thread.Comment.length > 0 &&
+                              typeof thread.Comment[0].markdown === "string"
+                                ? thread.Comment[0].markdown
+                                : "[Invalid Content]"
+
+                            return (
+                              <TableRow key={thread.id}>
+                                <TableCell sx={{ width: "25%", padding: "6px 12px" }}>
+                                  <Stack direction="row" spacing={1}>
+                                    <Avatar
+                                      className="pr-2"
+                                      size="xs"
+                                      rounded
+                                      img={users[thread.createdByEmail]?.image || undefined}
+                                    />
+                                    <>{thread.createdByEmail}</>
+                                  </Stack>
+                                </TableCell>
+                                <TableCell sx={{ width: "75%", padding: "6px 12px" }}>
+                                  <Link href={urlWithAnchor}>
+                                    <Typography variant="body1">{commentText}</Typography>
+                                  </Link>
+                                </TableCell>
+                              </TableRow>
+                            )
+                          })}
+                        </>
+                      )}
+                    </React.Fragment>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="h6">Resolved Comment Threads</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <TableContainer component={Paper}>
+            <Table aria-label="resolved threads table" size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell colSpan={3}>
+                    <Typography variant="body1" fontWeight="bold">
+                      Section Name
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {Object.keys(groupedResolvedThreads).map((sectionName) => {
+                  const isExpanded = expandedSections[sectionName] || false
+                  const firstThread = groupedResolvedThreads[sectionName][0]
+                  const { url } = sectionSplit(firstThread.section, material)
+
+                  return (
+                    <React.Fragment key={sectionName}>
+                      <TableRow onClick={() => toggleSection(sectionName)} style={{ cursor: "pointer" }}>
+                        <TableCell
+                          colSpan={3}
+                          sx={{
+                            backgroundColor: (theme) => (theme.palette.mode === "dark" ? "#000000" : "#e5e7eb"),
+                          }}
+                        >
+                          <Typography variant="body1" fontWeight="bold">
+                            {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />} {sectionName}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+
+                      {isExpanded && (
+                        <>
+                          <TableRow>
+                            <TableCell sx={{ width: "25%" }}>
+                              <strong>Created By</strong>
+                            </TableCell>
+                            <TableCell sx={{ width: "75%" }}>
+                              <strong>Comment</strong>
+                            </TableCell>
+                          </TableRow>
+                          {groupedResolvedThreads[sectionName].map((thread) => {
+                            const urlWithAnchor = url + `#comment-thread-${thread.id}`
+
+                            const commentText =
+                              thread.Comment &&
+                              thread.Comment.length > 0 &&
+                              typeof thread.Comment[0].markdown === "string"
+                                ? thread.Comment[0].markdown
+                                : "[Invalid Content]"
+
+                            return (
+                              <TableRow key={thread.id}>
+                                <TableCell sx={{ width: "25%", padding: "6px 12px" }}>
+                                  {/* <Avatar size="xs" rounded img={getAvatar(thread.createdByEmail) || undefined} /> */}
+                                  {thread.createdByEmail}
+                                </TableCell>
+                                <TableCell sx={{ width: "75%", padding: "2px 4px" }}>
+                                  <Link href={urlWithAnchor}>
+                                    <Typography variant="body1">{commentText}</Typography>
+                                  </Link>
+                                </TableCell>
+                              </TableRow>
+                            )
+                          })}
+                        </>
+                      )}
+                    </React.Fragment>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </AccordionDetails>
+      </Accordion>
     </div>
   )
 }

--- a/components/EventCommentThreads.tsx
+++ b/components/EventCommentThreads.tsx
@@ -20,9 +20,9 @@ import {
   Paper,
   Tooltip,
 } from "@mui/material"
+import LinkIcon from "@mui/icons-material/Link"
 import Stack from "./ui/Stack"
 import Thread from "./content/Thread"
-import { FaLink } from "react-icons/fa"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import ExpandLessIcon from "@mui/icons-material/ExpandLess"
 import { CommentThread } from "pages/api/commentThread/[commentThreadId]"
@@ -67,8 +67,6 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
 
   const { users, error: usersError } = useUsersList(emails)
 
-  console.log("us", users)
-
   useEffect(() => {
     if (commentThreads) {
       const unresolvedSectionNames = Object.keys(groupedUnresolvedThreads)
@@ -109,7 +107,6 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
   )
 
   const toggleSection = (sectionName: string) => {
-    console.log("toggleSection", sectionName, expandedSections)
     setExpandedSections((prevState) => ({
       ...prevState,
       [sectionName]: !prevState[sectionName],
@@ -151,6 +148,13 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
                         >
                           <Typography variant="body1" fontWeight="bold">
                             {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />} {sectionName}
+                            <LinkIcon
+                              onClick={(e) => {
+                                e.stopPropagation() // Prevent row click event from firing
+                                window.open(url, "_blank") // Open the link in a new tab
+                              }}
+                              style={{ marginLeft: 8, cursor: "pointer" }} // Adjust styling as needed
+                            />
                           </Typography>
                         </TableCell>
                       </TableRow>
@@ -259,6 +263,13 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
                         >
                           <Typography variant="body1" fontWeight="bold">
                             {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />} {sectionName}
+                            <LinkIcon
+                              onClick={(e) => {
+                                e.stopPropagation() // Prevent row click event from firing
+                                window.open(url, "_blank") // Open the link in a new tab
+                              }}
+                              style={{ marginLeft: 8, cursor: "pointer" }} // Adjust styling as needed
+                            />
                           </Typography>
                         </TableCell>
                       </TableRow>

--- a/components/EventCommentThreads.tsx
+++ b/components/EventCommentThreads.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react"
 import { Material, sectionSplit } from "lib/material"
 import { EventFull } from "lib/types"
-import { Avatar } from "flowbite-react"
+import Avatar from "@mui/material/Avatar"
 import Link from "next/link"
 import useCommentThreads from "lib/hooks/useCommentThreads"
 import { useTheme } from "next-themes"
@@ -84,12 +84,12 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
         initialExpandedState[sectionName] = true
       })
 
-      // ensure noSectionKey is collapsed
+      // ensure if the section was not found then that section is collapsed
       initialExpandedState[noSectionKey] = false
 
       setExpandedSections(initialExpandedState)
     }
-  }, [commentThreads]) // Only run when commentThreads change
+  }, [commentThreads])
 
   if (threadsIsLoading) return <div>Loading...</div>
   if (!commentThreads) return <div>Failed to load</div>
@@ -192,9 +192,9 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
                                   <Stack direction="row" spacing={1}>
                                     <Avatar
                                       className="pr-2"
-                                      size="xs"
-                                      rounded
-                                      img={users[thread.createdByEmail]?.image || undefined}
+                                      sx={{ width: 24, height: 24 }}
+                                      src={users[thread.createdByEmail]?.image || undefined}
+                                      alt={users[thread.createdByEmail]?.name || undefined}
                                     />
                                     <>{thread.createdByEmail}</>
                                   </Stack>
@@ -311,9 +311,8 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
                                   <Stack direction="row" spacing={1}>
                                     <Avatar
                                       className="pr-2"
-                                      size="xs"
-                                      rounded
-                                      img={users[thread.createdByEmail]?.image || undefined}
+                                      src={users[thread.createdByEmail]?.image || undefined}
+                                      alt={users[thread.createdByEmail]?.name || undefined}
                                     />
                                     <>{thread.createdByEmail}</>
                                   </Stack>

--- a/components/EventCommentThreads.tsx
+++ b/components/EventCommentThreads.tsx
@@ -116,7 +116,7 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
   return (
     <div>
       <Accordion defaultExpanded>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} data-cy="unresolved-threads-expand">
           <Typography variant="h6">Unresolved Comment Threads</Typography>
         </AccordionSummary>
         <AccordionDetails>
@@ -139,7 +139,11 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
 
                   return (
                     <React.Fragment key={sectionName}>
-                      <TableRow onClick={() => toggleSection(sectionName)} style={{ cursor: "pointer" }}>
+                      <TableRow
+                        onClick={() => toggleSection(sectionName)}
+                        style={{ cursor: "pointer" }}
+                        data-cy={`section:${sectionName}:unresolved`}
+                      >
                         <TableCell
                           colSpan={3}
                           sx={{
@@ -231,7 +235,7 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
       </Accordion>
 
       <Accordion>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} data-cy="resolved-threads-expand">
           <Typography variant="h6">Resolved Comment Threads</Typography>
         </AccordionSummary>
         <AccordionDetails>
@@ -254,7 +258,11 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
 
                   return (
                     <React.Fragment key={sectionName}>
-                      <TableRow onClick={() => toggleSection(sectionName)} style={{ cursor: "pointer" }}>
+                      <TableRow
+                        onClick={() => toggleSection(sectionName)}
+                        style={{ cursor: "pointer" }}
+                        data-cy={`section:${sectionName}:resolved`}
+                      >
                         <TableCell
                           colSpan={3}
                           sx={{

--- a/components/EventCommentThreads.tsx
+++ b/components/EventCommentThreads.tsx
@@ -18,8 +18,11 @@ import {
   TableHead,
   TableRow,
   Paper,
+  Tooltip,
 } from "@mui/material"
 import Stack from "./ui/Stack"
+import Thread from "./content/Thread"
+import { FaLink } from "react-icons/fa"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import ExpandLessIcon from "@mui/icons-material/ExpandLess"
 import { CommentThread } from "pages/api/commentThread/[commentThreadId]"
@@ -52,6 +55,7 @@ type Props = {
 }
 
 const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
+  const [activeThreadId, setActiveThreadId] = useState<number | undefined>(undefined)
   const { commentThreads, error: threadsError, isLoading: threadsIsLoading } = useCommentThreads(event.id)
   const [expandedSections, setExpandedSections] = useState<{ [key: string]: boolean }>({})
   const { theme: currentTheme } = useTheme()
@@ -160,6 +164,9 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
                             <TableCell sx={{ width: "75%" }}>
                               <strong>Comment</strong>
                             </TableCell>
+                            <TableCell sx={{ width: "10%" }}>
+                              <strong>Expand</strong>
+                            </TableCell>
                           </TableRow>
                           {groupedUnresolvedThreads[sectionName].map((thread) => {
                             const urlWithAnchor = url + `#comment-thread-${thread.id}`
@@ -173,7 +180,7 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
 
                             return (
                               <TableRow key={thread.id}>
-                                <TableCell sx={{ width: "25%", padding: "6px 12px" }}>
+                                <TableCell sx={{ width: "25%" }}>
                                   <Stack direction="row" spacing={1}>
                                     <Avatar
                                       className="pr-2"
@@ -184,10 +191,26 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
                                     <>{thread.createdByEmail}</>
                                   </Stack>
                                 </TableCell>
-                                <TableCell sx={{ width: "75%", padding: "6px 12px" }}>
+                                <TableCell sx={{ width: "75%" }}>
                                   <Link href={urlWithAnchor}>
-                                    <Typography variant="body1">{commentText}</Typography>
+                                    <Typography variant="body1">
+                                      <Tooltip title="Go to comment thread">
+                                        <span>{commentText}</span>
+                                      </Tooltip>
+                                    </Typography>
                                   </Link>
+                                </TableCell>
+                                <TableCell sx={{ width: "25%" }}>
+                                  <Thread
+                                    key={thread.id}
+                                    thread={thread.id}
+                                    active={activeThreadId === thread.id}
+                                    setActive={(active: boolean) =>
+                                      active ? setActiveThreadId(thread.id) : setActiveThreadId(undefined)
+                                    }
+                                    finaliseThread={() => {}}
+                                    onDelete={() => {}}
+                                  />
                                 </TableCell>
                               </TableRow>
                             )
@@ -249,6 +272,9 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
                             <TableCell sx={{ width: "75%" }}>
                               <strong>Comment</strong>
                             </TableCell>
+                            <TableCell sx={{ width: "10%" }}>
+                              <strong>Expand</strong>
+                            </TableCell>
                           </TableRow>
                           {groupedResolvedThreads[sectionName].map((thread) => {
                             const urlWithAnchor = url + `#comment-thread-${thread.id}`
@@ -262,14 +288,37 @@ const EventCommentThreads: React.FC<Props> = ({ material, event }) => {
 
                             return (
                               <TableRow key={thread.id}>
-                                <TableCell sx={{ width: "25%", padding: "6px 12px" }}>
-                                  {/* <Avatar size="xs" rounded img={getAvatar(thread.createdByEmail) || undefined} /> */}
-                                  {thread.createdByEmail}
+                                <TableCell sx={{ width: "25%" }}>
+                                  <Stack direction="row" spacing={1}>
+                                    <Avatar
+                                      className="pr-2"
+                                      size="xs"
+                                      rounded
+                                      img={users[thread.createdByEmail]?.image || undefined}
+                                    />
+                                    <>{thread.createdByEmail}</>
+                                  </Stack>
                                 </TableCell>
-                                <TableCell sx={{ width: "75%", padding: "2px 4px" }}>
+                                <TableCell sx={{ width: "75%" }}>
                                   <Link href={urlWithAnchor}>
-                                    <Typography variant="body1">{commentText}</Typography>
+                                    <Typography variant="body1">
+                                      <Tooltip title={`Go to comment thread: ${thread.textRef}`}>
+                                        <span>{commentText}</span>
+                                      </Tooltip>
+                                    </Typography>
                                   </Link>
+                                </TableCell>
+                                <TableCell sx={{ width: "10%" }}>
+                                  <Thread
+                                    key={thread.id}
+                                    thread={thread.id}
+                                    active={activeThreadId === thread.id}
+                                    setActive={(active: boolean) =>
+                                      active ? setActiveThreadId(thread.id) : setActiveThreadId(undefined)
+                                    }
+                                    finaliseThread={() => {}}
+                                    onDelete={() => {}}
+                                  />
                                 </TableCell>
                               </TableRow>
                             )

--- a/components/EventProblems.tsx
+++ b/components/EventProblems.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import { Course, Material, Section, Theme, eventItemSplit } from "lib/material"
 import { EventFull, Event, Problem } from "lib/types"
-import { Avatar, Table } from "flowbite-react"
+import { Table } from "flowbite-react"
+import Avatar from "@mui/material/Avatar"
 import { useProblems } from "lib/hooks/useProblems"
 import useUsersOnEvent from "lib/hooks/useUsersOnEvent"
 import Tooltip from "@mui/material/Tooltip"
@@ -36,7 +37,7 @@ const EventProblems: React.FC<Props> = ({ material, event }) => {
           <Table.HeadCell key={user.userEmail} align="center" className="p-0">
             <Tooltip title={`${user?.user?.name} <${user?.userEmail}>`}>
               <div>
-                <Avatar img={user?.user?.image || undefined} rounded={true} size="xs" />
+                <Avatar src={user?.user?.image || undefined} />
               </div>
             </Tooltip>
           </Table.HeadCell>

--- a/components/EventUsers.tsx
+++ b/components/EventUsers.tsx
@@ -4,7 +4,8 @@ import { Material } from "lib/material"
 import { EventFull, Event, Problem } from "lib/types"
 import useSWR, { Fetcher } from "swr"
 import Title from "components/ui/Title"
-import { Avatar, Button, Card, Timeline } from "flowbite-react"
+import { Button, Card, Timeline } from "flowbite-react"
+import Avatar from "@mui/material/Avatar"
 import { ListGroup } from "flowbite-react"
 import { basePath } from "lib/basePath"
 import { useFieldArray, useForm } from "react-hook-form"
@@ -88,7 +89,7 @@ const EventUsers: React.FC<Props> = ({ event }) => {
                   <li className="py-3 sm:py-4">
                     <div className="flex items-center space-x-4">
                       <div className="shrink-0">
-                        <Avatar img={user.user.image || undefined} rounded={true} size="sm" />
+                        <Avatar src={user.user.image || undefined} alt={user.user.name || undefined} />
                       </div>
                       <div className="min-w-0 flex-1">
                         <p className="truncate text-sm font-medium text-gray-900 dark:text-white">{user.user.name}</p>

--- a/components/MuiTheme.tsx
+++ b/components/MuiTheme.tsx
@@ -21,7 +21,42 @@ export const LightTheme = createTheme({
         root: {
           backgroundColor: "#f8fafc", // Similar to bg-slate-50
           borderColor: "#e5e7eb", // border-gray-200
-          borderRadius: "8", // rounded-lg
+          borderRadius: "8px", // rounded-lg
+        },
+      },
+    },
+    MuiTable: {
+      styleOverrides: {
+        root: {
+          backgroundColor: "#f8fafc", // Table background similar to paper
+        },
+      },
+    },
+    MuiTableCell: {
+      styleOverrides: {
+        root: {
+          borderColor: "#e5e7eb", // border-gray-200 for light borders
+          padding: "6px 12px", // Reduce padding to align with Tailwind-style compactness
+        },
+        head: {
+          backgroundColor: "#f1f5f9", // Header bg like bg-slate-100
+          color: "#374151", // Header text color like text-gray-700
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          backgroundColor: "#f1f5f9", // bg-slate-100
+        },
+      },
+    },
+    MuiTableRow: {
+      styleOverrides: {
+        root: {
+          "&:nth-of-type(even)": {
+            backgroundColor: "#f9fafb", // Alternating row color like bg-slate-50
+          },
         },
       },
     },
@@ -50,6 +85,49 @@ export const DarkTheme = createTheme({
           backgroundColor: "#374151", // Similar to dark:bg-slate-800
           borderColor: "#4b5563", // dark:border-gray-700
           borderRadius: "8px", // rounded-lg
+        },
+      },
+    },
+    MuiAccordion: {
+      styleOverrides: {
+        root: {
+          backgroundColor: "#111827", // dark:bg-slate-900 for dark mode
+        },
+      },
+    },
+    MuiTable: {
+      styleOverrides: {
+        root: {
+          backgroundColor: "#374151", // dark:bg-slate-800 for table background
+        },
+      },
+    },
+    MuiTableCell: {
+      styleOverrides: {
+        root: {
+          borderColor: "#4b5563", // dark:border-gray-700 for dark mode borders
+          padding: "4px 8px", // Reduce padding for compactness
+          color: "#e5e7eb", // light gray text color like text-gray-300
+        },
+        head: {
+          backgroundColor: "#4b5563", // dark:bg-gray-700 for header background
+          color: "#e5e7eb", // Header text color like text-gray-300
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          backgroundColor: "#4b5563", // dark:bg-gray-700 for header background
+        },
+      },
+    },
+    MuiTableRow: {
+      styleOverrides: {
+        root: {
+          "&:nth-of-type(even)": {
+            backgroundColor: "#1f2937", // Alternating row color like dark:bg-slate-800
+          },
         },
       },
     },

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,4 +1,5 @@
-import { Avatar, Button, Dropdown, Tooltip } from "flowbite-react"
+import { Button, Dropdown, Tooltip } from "flowbite-react"
+import Avatar from "@mui/material/Avatar"
 import { Course, Material, Section, Theme, getExcludes, Excludes } from "lib/material"
 import { Event, EventFull } from "lib/types"
 import { signIn, signOut, useSession } from "next-auth/react"
@@ -439,15 +440,12 @@ const Navbar: React.FC<Props> = ({
               <span className="inline-flex items-center text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white w-10 h-10">
                 {session ? (
                   <Avatar
-                    role="img"
-                    img={session.user?.image ? session.user?.image : undefined}
-                    className="w-8 h-8"
-                    size="sm"
-                    rounded={true}
+                    src={session.user?.image ? session.user?.image : undefined}
+                    sx={{ width: 32, height: 32 }}
                     data-cy={`avatar-${session.user?.email}`}
                   />
                 ) : (
-                  <Avatar role="img" className="w-8 h-8" size="sm" rounded={true} data-cy={`avatar-not-signed-in`} />
+                  <Avatar sx={{ width: 32, height: 32 }} data-cy={`avatar-not-signed-in`} />
                 )}
               </span>
             }

--- a/components/content/Comment.tsx
+++ b/components/content/Comment.tsx
@@ -1,4 +1,5 @@
-import { Avatar, Button, Card, Dropdown, Tabs, Tooltip } from "flowbite-react"
+import { Button, Card, Dropdown, Tabs, Tooltip } from "flowbite-react"
+import Avatar from "@mui/material/Avatar"
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Markdown } from "./Content"
 import { Comment } from "pages/api/comment/[commentId]"
@@ -117,7 +118,7 @@ const CommentView = ({
                     </>
                   }
                 >
-                  <Avatar size="xs" rounded img={user?.image || undefined} />
+                  <Avatar src={user?.image || undefined} alt={user?.name || "Sign in"} />
                 </Tooltip>
               </div>
             )}

--- a/components/content/Paragraph.tsx
+++ b/components/content/Paragraph.tsx
@@ -136,7 +136,7 @@ const Paragraph: React.FC<ParagraphProps> = ({ content, section }) => {
   return (
     <>
       <div data-cy="paragraph" ref={ref} className="relative pb-2">
-        <p className="m-0 pb-0">{content}</p>
+        <div className="m-0 pb-0">{content}</div>
         {activeEvent && (
           <div className={`absolute top-0 right-0 md:-right-6 xl:-right-[420px]`}>
             <div className={`w-[420px]`}>

--- a/components/content/Thread.tsx
+++ b/components/content/Thread.tsx
@@ -56,6 +56,7 @@ interface ThreadProps {
   setActive: (active: boolean) => void
   onDelete: () => void
   finaliseThread: (thread: CommentThread, comment: Comment) => void
+  initialAnchor?: { top: number; left: number }
 }
 
 function useResolveThread(thread: number | CommentThread) {
@@ -84,7 +85,7 @@ function useResolveThread(thread: number | CommentThread) {
   return { commentThread, threadId, commentThreadIsLoading, isLoading, isPlaceholder, mutate }
 }
 
-const Thread = ({ thread, active, setActive, onDelete, finaliseThread }: ThreadProps) => {
+const Thread = ({ thread, active, setActive, onDelete, finaliseThread, initialAnchor }: ThreadProps) => {
   const { commentThread, threadId, commentThreadIsLoading, isLoading, isPlaceholder, mutate } = useResolveThread(thread)
   const { user, isLoading: userIsLoading, error: userError } = useUser(commentThread?.createdByEmail)
   const { userProfile, isLoading: profileLoading, error: profileError } = useProfile()
@@ -97,10 +98,13 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread }: ThreadP
     mutate: mutateEvent,
   } = useEvent(activeEvent?.id)
 
-  const popupRef = useRef<HTMLDivElement | null>(null) // Reference for the popup element
-  const triggerRef = useRef<HTMLDivElement | null>(null) // Reference for the trigger (Thread component)
+  const popupRef = useRef<HTMLDivElement | null>(null) // Reference for the popup element (the comment thread)
+  const triggerRef = useRef<HTMLDivElement | null>(null) // Reference for the trigger (Thread component) in paragraph
 
-  const [popupPosition, setPopupPosition] = useState({ top: 0, left: 0 })
+  const [popupPosition, setPopupPosition] = useState(
+    initialAnchor || { top: 0, left: 0 } // Use initialAnchor if provided
+  )
+
   const calculatePosition = () => {
     if (triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect()
@@ -122,7 +126,7 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread }: ThreadP
 
   useEffect(() => {
     if (active) {
-      calculatePosition() // Calculate the position when the popup is active
+      calculatePosition()
     }
   }, [active]) // Recalculate when the active state changes
 
@@ -243,7 +247,7 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread }: ThreadP
         <div className={`flex items-center justify-between rounded-t-lg`}>
           <h3 className="w-full mx-2 my-0 text-base text-slate-100 dark:text-slate-900">{}</h3>
           <Stack direction="row-reverse">
-            <TinyButton onClick={() => setActive(false)}>
+            <TinyButton onClick={() => setActive(false)} dataCy={`Thread:${threadId}:CloseButton`}>
               <IoClose />
             </TinyButton>
             {!isPlaceholder && (

--- a/components/content/Thread.tsx
+++ b/components/content/Thread.tsx
@@ -108,17 +108,17 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread, initialAn
   const calculatePosition = () => {
     if (triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect()
-      const popupWidth = 355 // Adjust this value based on your actual popup width
+      const popupWidth = 355
       const viewportWidth = window.innerWidth
 
-      let leftPosition = rect.right + 10 // Position to the right of the thread
+      let leftPosition = rect.left + 35
       if (leftPosition + popupWidth > viewportWidth) {
         // If the popup overflows the viewport, adjust to the left
         leftPosition = rect.left - popupWidth - 10
       }
 
       setPopupPosition({
-        top: rect.top + window.scrollY, // Account for vertical scroll
+        top: rect.top + window.scrollY,
         left: leftPosition,
       })
     }
@@ -128,7 +128,7 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread, initialAn
     if (active) {
       calculatePosition()
     }
-  }, [active]) // Recalculate when the active state changes
+  }, [active]) // Recalculate popup position when the thread is opened
 
   const sortedComments = useMemo(() => {
     if (!commentThread) return []
@@ -332,7 +332,7 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread, initialAn
           </Stack>
         )}
       </div>,
-      document.body // Render the popup in the root of the document
+      document.body // Render the popup in the body
     )
   }
 

--- a/components/content/Thread.tsx
+++ b/components/content/Thread.tsx
@@ -1,4 +1,5 @@
-import { Avatar, Button, ButtonProps, Card, Checkbox, Dropdown, Label, Spinner, Tooltip } from "flowbite-react"
+import { Button, ButtonProps, Card, Checkbox, Dropdown, Label, Spinner, Tooltip } from "flowbite-react"
+import Avatar from "@mui/material/Avatar"
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Markdown } from "./Content"
 import { CommentThread, Comment } from "pages/api/commentThread"
@@ -234,7 +235,7 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread, initialAn
             }
           >
             <Stack direction="row" spacing={2} className="justify-center">
-              <Avatar size="xs" rounded img={user?.image || undefined} />
+              <Avatar sx={{ width: 32, height: 32 }} src={user?.image || undefined} alt={user?.name || "Sign in"} />
               {commentThread?.resolved === true && (
                 <GoIssueClosed
                   className="h-6 w-6 font-bold text-green dark:text-green-600"

--- a/components/content/Thread.tsx
+++ b/components/content/Thread.tsx
@@ -101,7 +101,6 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread }: ThreadP
   const triggerRef = useRef<HTMLDivElement | null>(null) // Reference for the trigger (Thread component)
 
   const [popupPosition, setPopupPosition] = useState({ top: 0, left: 0 })
-  console.log("Popup position", popupPosition)
   const calculatePosition = () => {
     if (triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect()

--- a/components/content/Thread.tsx
+++ b/components/content/Thread.tsx
@@ -15,7 +15,7 @@ import putCommentThread from "lib/actions/putCommentThread"
 import useActiveEvent from "lib/hooks/useActiveEvents"
 import useEvent from "lib/hooks/useEvent"
 import useProfile from "lib/hooks/useProfile"
-
+import { createPortal } from "react-dom"
 import Stack from "components/ui/Stack"
 
 import { GoIssueClosed } from "react-icons/go"
@@ -97,6 +97,36 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread }: ThreadP
     mutate: mutateEvent,
   } = useEvent(activeEvent?.id)
 
+  const popupRef = useRef<HTMLDivElement | null>(null) // Reference for the popup element
+  const triggerRef = useRef<HTMLDivElement | null>(null) // Reference for the trigger (Thread component)
+
+  const [popupPosition, setPopupPosition] = useState({ top: 0, left: 0 })
+  console.log("Popup position", popupPosition)
+  const calculatePosition = () => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect()
+      const popupWidth = 355 // Adjust this value based on your actual popup width
+      const viewportWidth = window.innerWidth
+
+      let leftPosition = rect.right + 10 // Position to the right of the thread
+      if (leftPosition + popupWidth > viewportWidth) {
+        // If the popup overflows the viewport, adjust to the left
+        leftPosition = rect.left - popupWidth - 10
+      }
+
+      setPopupPosition({
+        top: rect.top + window.scrollY, // Account for vertical scroll
+        left: leftPosition,
+      })
+    }
+  }
+
+  useEffect(() => {
+    if (active) {
+      calculatePosition() // Calculate the position when the popup is active
+    }
+  }, [active]) // Recalculate when the active state changes
+
   const sortedComments = useMemo(() => {
     if (!commentThread) return []
     return commentThread.Comment.sort((a, b) => a.index - b.index)
@@ -138,6 +168,7 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread }: ThreadP
   }
 
   const handleOpen = () => {
+    calculatePosition()
     setActive(!active)
   }
 
@@ -175,9 +206,136 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread }: ThreadP
     })
   }
 
+  const renderPopup = () => {
+    if (!active) return null
+
+    return createPortal(
+      <div
+        ref={popupRef}
+        className="absolute w-[355px] border border-gray-200 rounded-lg bg-slate-50 dark:bg-slate-900 dark:border-gray-700 z-50"
+        style={{ top: `${popupPosition.top}px`, left: `${popupPosition.left}px` }} // Apply calculated position
+        data-cy={`Thread:${threadId}:Main`}
+      >
+        <div className="absolute -top-1 left-0 not-prose">
+          <Tooltip
+            content={
+              <>
+                <span className="block text-sm">{user?.name}</span>
+                <span className="block truncate text-sm font-medium">{commentThread?.createdByEmail}</span>
+                <span className="block text-sm">
+                  {commentThread?.created
+                    ? new Date(commentThread?.created).toLocaleString([], { dateStyle: "medium", timeStyle: "short" })
+                    : ""}
+                </span>
+              </>
+            }
+          >
+            <Stack direction="row" spacing={2} className="justify-center">
+              <Avatar size="xs" rounded img={user?.image || undefined} />
+              {commentThread?.resolved === true && (
+                <GoIssueClosed
+                  className="h-6 w-6 font-bold text-green dark:text-green-600"
+                  data-cy={`Thread:${threadId}:IsResolved`}
+                />
+              )}
+            </Stack>
+          </Tooltip>
+        </div>
+        <div className={`flex items-center justify-between rounded-t-lg`}>
+          <h3 className="w-full mx-2 my-0 text-base text-slate-100 dark:text-slate-900">{}</h3>
+          <Stack direction="row-reverse">
+            <TinyButton onClick={() => setActive(false)}>
+              <IoClose />
+            </TinyButton>
+            {!isPlaceholder && (
+              <Dropdown
+                renderTrigger={() => (
+                  <TinyButton>
+                    <BiDotsVerticalRounded className="h-4 w-4" data-cy={`Thread:${threadId}:Dropdown`} />
+                  </TinyButton>
+                )}
+                label={undefined}
+                className="not-prose"
+              >
+                <Dropdown.Item
+                  className="hover:bg-gray-400"
+                  icon={commentThread?.instructorOnly === true ? ImEyeBlocked : ImEye}
+                  onClick={handleInstructorOnly}
+                  data-cy={`Thread:${threadId}:Visibility`}
+                >
+                  Visibility
+                </Dropdown.Item>
+                <Dropdown.Item
+                  className="hover:bg-gray-400"
+                  icon={MdDelete}
+                  onClick={handleDelete}
+                  data-cy={`Thread:${threadId}:Delete`}
+                >
+                  Delete
+                </Dropdown.Item>
+              </Dropdown>
+            )}
+          </Stack>
+        </div>
+        {isPlaceholder &&
+          sortedComments.map((comment) => (
+            <RecoilRoot key={comment.id}>
+              <CommentView
+                key={comment.id}
+                comment={comment}
+                mutateComment={savePlaceholder}
+                saveComment={savePlaceholder}
+                deleteComment={deleteComment}
+                isPlaceholder={true}
+                threadEditing={threadEditing}
+                setThreadEditing={setThreadEditing}
+              />
+            </RecoilRoot>
+          ))}
+        {!isPlaceholder &&
+          sortedComments.map((comment) => (
+            <RecoilRoot key={comment.id}>
+              <CommentView
+                key={comment.id}
+                comment={comment}
+                mutateComment={mutateComment}
+                deleteComment={deleteComment}
+                isPlaceholder={false}
+                threadEditing={threadEditing}
+                setThreadEditing={setThreadEditing}
+              />
+            </RecoilRoot>
+          ))}
+        {!isPlaceholder && (
+          <Stack direction="row-reverse">
+            {canResolve && (
+              <Tooltip content="Mark as Resolved" placement="top">
+                <TinyButton onClick={handleResolved} dataCy={`Thread:${threadId}:Resolved`}>
+                  {commentThread?.resolved ? (
+                    <GoIssueClosed className="h-4 w-4 text-green dark:text-green-600" />
+                  ) : (
+                    <GoIssueClosed className="h-4 w-4" />
+                  )}
+                </TinyButton>
+              </Tooltip>
+            )}
+            {!threadEditing && (
+              <Tooltip content="Reply in Thread" placement="top">
+                <TinyButton onClick={handleReply}>
+                  <BiReply className="h-4 w-4" data-cy={`Thread:${threadId}:Reply`} />
+                </TinyButton>
+              </Tooltip>
+            )}
+          </Stack>
+        )}
+      </div>,
+      document.body // Render the popup in the root of the document
+    )
+  }
+
   return (
     <div className="relative" id={`comment-thread-${threadId}`}>
-      <div className="flex justify-end opacity-50 md:opacity-100 xl:justify-start">
+      <div className="flex justify-end opacity-50 md:opacity-100 xl:justify-start" ref={triggerRef}>
         <TinyButton onClick={handleOpen} dataCy={`Thread:${threadId}:OpenCloseButton`}>
           {commentThread?.resolved ? (
             <BiCommentCheck className="text-green dark:text-green-600" />
@@ -186,125 +344,7 @@ const Thread = ({ thread, active, setActive, onDelete, finaliseThread }: ThreadP
           )}
         </TinyButton>
       </div>
-      {active && (
-        <div
-          className="absolute ml-8 top-0 w-[355px] border border-gray-200 rounded-lg bg-slate-50 dark:bg-slate-900 dark:border-gray-700 mb-4 z-50 "
-          data-cy={`Thread:${threadId}:Main`}
-        >
-          <div className="absolute -top-1 left-0 not-prose">
-            <Tooltip
-              content={
-                <>
-                  <span className="block text-sm">{user?.name}</span>
-                  <span className="block truncate text-sm font-medium">{commentThread?.createdByEmail}</span>
-                  <span className="block text-sm">
-                    {commentThread?.created
-                      ? new Date(commentThread?.created).toLocaleString([], { dateStyle: "medium", timeStyle: "short" })
-                      : ""}
-                  </span>
-                </>
-              }
-            >
-              <Stack direction="row" spacing={2} className="justify-center">
-                <Avatar size="xs" rounded img={user?.image || undefined} />
-                {commentThread?.resolved === true && (
-                  <GoIssueClosed
-                    className="h-6 w-6 font-bold text-green dark:text-green-600"
-                    data-cy={`Thread:${threadId}:IsResolved`}
-                  />
-                )}
-              </Stack>
-            </Tooltip>
-          </div>
-          <div className={`flex items-center justify-between rounded-t-lg`}>
-            <h3 className="w-full mx-2 my-0 text-base text-slate-100 dark:text-slate-900">{}</h3>
-            <Stack direction="row-reverse">
-              <TinyButton onClick={handleClose}>
-                <IoClose />
-              </TinyButton>
-              {!isPlaceholder && (
-                <Dropdown
-                  renderTrigger={() => (
-                    <TinyButton>
-                      <BiDotsVerticalRounded className="h-4 w-4" data-cy={`Thread:${threadId}:Dropdown`} />
-                    </TinyButton>
-                  )}
-                  label={undefined}
-                  className="not-prose"
-                >
-                  <Dropdown.Item
-                    className="hover:bg-gray-400"
-                    icon={commentThread?.instructorOnly === true ? ImEyeBlocked : ImEye}
-                    onClick={handleInstructorOnly}
-                    data-cy={`Thread:${threadId}:Visibility`}
-                  >
-                    Visibility
-                  </Dropdown.Item>
-                  <Dropdown.Item
-                    className="hover:bg-gray-400"
-                    icon={MdDelete}
-                    onClick={handleDelete}
-                    data-cy={`Thread:${threadId}:Delete`}
-                  >
-                    Delete
-                  </Dropdown.Item>
-                </Dropdown>
-              )}
-            </Stack>
-          </div>
-          {isPlaceholder &&
-            sortedComments.map((comment) => (
-              <RecoilRoot key={comment.id}>
-                <CommentView
-                  key={comment.id}
-                  comment={comment}
-                  mutateComment={savePlaceholder}
-                  saveComment={savePlaceholder}
-                  deleteComment={deleteComment}
-                  isPlaceholder={true}
-                  threadEditing={threadEditing}
-                  setThreadEditing={setThreadEditing}
-                />
-              </RecoilRoot>
-            ))}
-          {!isPlaceholder &&
-            sortedComments.map((comment) => (
-              <RecoilRoot key={comment.id}>
-                <CommentView
-                  key={comment.id}
-                  comment={comment}
-                  mutateComment={mutateComment}
-                  deleteComment={deleteComment}
-                  isPlaceholder={false}
-                  threadEditing={threadEditing}
-                  setThreadEditing={setThreadEditing}
-                />
-              </RecoilRoot>
-            ))}
-          {!isPlaceholder && (
-            <Stack direction="row-reverse">
-              {canResolve && (
-                <Tooltip content="Mark as Resolved" placement="top">
-                  <TinyButton onClick={handleResolved} dataCy={`Thread:${threadId}:Resolved`}>
-                    {commentThread?.resolved ? (
-                      <GoIssueClosed className="h-4 w-4 text-green dark:text-green-600" />
-                    ) : (
-                      <GoIssueClosed className="h-4 w-4" />
-                    )}
-                  </TinyButton>
-                </Tooltip>
-              )}
-              {!threadEditing && (
-                <Tooltip content="Reply in Thread" placement="top">
-                  <TinyButton onClick={handleReply}>
-                    <BiReply className="h-4 w-4" data-cy={`Thread:${threadId}:Reply`} />
-                  </TinyButton>
-                </Tooltip>
-              )}
-            </Stack>
-          )}
-        </div>
-      )}
+      {renderPopup()} {/* Render the popup using a portal */}
     </div>
   )
 }

--- a/cypress/component/EventCommentThreads.cy.tsx
+++ b/cypress/component/EventCommentThreads.cy.tsx
@@ -1,4 +1,5 @@
 import EventCommentThreads from "components/EventCommentThreads"
+import { data } from "cypress/types/jquery"
 import { Material } from "lib/material"
 import { EventFull } from "lib/types"
 import { CommentThread } from "pages/api/commentThread/[commentThreadId]"
@@ -63,7 +64,7 @@ describe("EventCommentThreads component", () => {
         },
       ],
     }
-
+    // These are threads that will be associated with unresolved sections (No section)
     const threads: CommentThread[] = [
       {
         id: 1,
@@ -113,15 +114,102 @@ describe("EventCommentThreads component", () => {
           },
         ],
       },
+      {
+        id: 3,
+        eventId: 1,
+        groupId: null,
+        section: "test.theme1.course1.section1",
+        problemTag: "",
+        textRef: "",
+        textRefStart: 0,
+        textRefEnd: 0,
+        createdByEmail: "student@gmail.com",
+        created: new Date(),
+        resolved: false,
+        instructorOnly: false,
+        Comment: [
+          {
+            id: 1,
+            threadId: 1,
+            createdByEmail: "student@gmail.com",
+            created: new Date(),
+            index: 0,
+            markdown: "This is an unresolved thread in a verified section",
+          },
+        ],
+      },
+      {
+        id: 4,
+        eventId: 1,
+        groupId: null,
+        section: "test.theme1.course1.section1",
+        problemTag: "",
+        textRef: "",
+        textRefStart: 0,
+        textRefEnd: 0,
+        createdByEmail: "student@gmail.com",
+        created: new Date(),
+        resolved: true,
+        instructorOnly: false,
+        Comment: [
+          {
+            id: 1,
+            threadId: 1,
+            createdByEmail: "student@gmail.com",
+            created: new Date(),
+            index: 0,
+            markdown: "This is a resolved thread in a verified section",
+          },
+        ],
+      },
     ]
 
     cy.intercept("/api/commentThread?eventId=1", { commentThreads: threads }).as("commentThreads")
     cy.mount(<EventCommentThreads event={event} material={material} />)
     cy.wait("@commentThreads")
   })
+  context("For threads associated with a missing section", () => {
+    it("shows unresolved threads by default", () => {
+      cy.get('[data-cy="section:No Section found (material changed?):unresolved"]').click()
+      cy.contains("thankyou").should("not.be.visible")
+      cy.contains("this is not workin!").should("be.visible")
+    })
 
-  it("shows unresolved threads", () => {
-    cy.contains("thankyou").should("not.exist")
-    cy.contains("this is not workin!").should("exist")
+    it("can hide unresolved threads", () => {
+      cy.get('[data-cy="section:No Section found (material changed?):unresolved"]').should("be.visible")
+      cy.get('[data-cy="unresolved-threads-expand"]').click()
+      cy.get('[data-cy="section:No Section found (material changed?):unresolved"]').should("not.be.visible")
+    })
+
+    it("shows resolved threads when clicked", () => {
+      cy.get('[data-cy="resolved-threads-expand"]').click()
+      cy.get('[data-cy="section:No Section found (material changed?):resolved"]').should("be.visible")
+      cy.get('[data-cy="section:No Section found (material changed?):resolved"]').click()
+      cy.contains("thankyou").should("be.visible")
+    })
+  })
+  context("For threads in 'Section 1'", () => {
+    it("shows unresolved threads by default, can hide", () => {
+      cy.contains("This is an unresolved thread in a verified section").should("be.visible")
+      cy.contains("This is a resolved thread in a verified section").should("not.be.visible")
+      cy.get('[data-cy="unresolved-threads-expand"]').should("be.visible").click()
+      cy.contains("This is an unresolved thread in a verified section").should("not.be.visible")
+    })
+
+    it("can hide sections", () => {
+      cy.contains("This is an unresolved thread in a verified section").should("be.visible")
+      cy.get('[data-cy="section:Section 1:unresolved"]').click()
+      cy.wait(100)
+      cy.contains("This is an unresolved thread in a verified section").should("not.exist")
+    })
+
+    it("shows resolved threads when clicked", () => {
+      cy.get('[data-cy="section:Section 1:resolved"]').should("not.be.visible")
+      cy.get('[data-cy="resolved-threads-expand"]').click()
+      cy.get('[data-cy="section:No Section found (material changed?):resolved"]').should("be.visible")
+      cy.contains("This is a resolved thread in a verified section").should("be.visible")
+      cy.get('[data-cy="section:Section 1:resolved"]').should("be.visible").click()
+      cy.contains("This is a resolved thread in a verified section").should("not.exist")
+    })
   })
 })

--- a/lib/hooks/useUsersList.ts
+++ b/lib/hooks/useUsersList.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react"
+import useSWR from "swr"
+import { basePath } from "lib/basePath"
+import { User, UserPublic } from "pages/api/user/[email]"
+
+// Single user fetcher for individual email
+const fetchUser = async (email: string): Promise<User | UserPublic | undefined> => {
+  const response = await fetch(`${basePath}/api/user/${email}`)
+  const data = await response.json()
+  return data.user
+}
+
+const useUsersList = (emails: string[]) => {
+  const [users, setUsers] = useState<{ [email: string]: User | UserPublic | undefined }>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    const uniqueEmails = Array.from(new Set(emails)) // Avoid duplicate requests for the same email
+    setLoading(true)
+
+    const fetchUsers = async () => {
+      try {
+        const fetchedUsers: { [email: string]: User | UserPublic | undefined } = {}
+        await Promise.all(
+          uniqueEmails.map(async (email) => {
+            const user = await fetchUser(email)
+            if (user) {
+              fetchedUsers[email] = user
+            }
+          })
+        )
+        setUsers(fetchedUsers)
+        setLoading(false)
+      } catch (err) {
+        setError("Failed to load users")
+        setLoading(false)
+      }
+    }
+
+    if (uniqueEmails.length > 0) {
+      fetchUsers()
+    }
+  }, [emails])
+
+  return { users, loading, error }
+}
+
+export default useUsersList

--- a/pages/event/[eventId].tsx
+++ b/pages/event/[eventId].tsx
@@ -8,7 +8,8 @@ import NavDiagram from "components/navdiagram/NavDiagram"
 import Title from "components/ui/Title"
 import type { Event, EventFull } from "lib/types"
 import { basePath } from "lib/basePath"
-import { Avatar, Button, Card, Tabs } from "flowbite-react"
+import { Button, Card, Tabs } from "flowbite-react"
+import Avatar from "@mui/material/Avatar"
 import EventProblems from "components/EventProblems"
 import { useForm, Controller, useFieldArray } from "react-hook-form"
 import { useSession } from "next-auth/react"
@@ -145,7 +146,7 @@ const Event: NextPage<EventProps> = ({ material, event, pageInfo }) => {
           {eventUser.map((user, index) => (
             <div key={user.id} className="flex items-center space-x-4">
               <div className="shrink-0">
-                <Avatar img={user.user?.image || undefined} rounded={true} size="sm" />
+                <Avatar src={user.user?.image || undefined} alt={user.user?.name || undefined} />
               </div>
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium text-gray-900 dark:text-white">{user.user?.name}</p>


### PR DESCRIPTION
I wanted to fix #269 and so took a pass at the whole table:

There are now 2 tables for resolved and unresolved comments, the unresolved starts off collapsed.

Because on old events there will be broken links (see #270) there will be threads that you cant link from, these are grouped into an automatically hidden section (No section found)

Comments are now grouped by the section they originated on (again collapsible) there are now links to the whole section and perhaps the most cool thing is that the thread itself can now be opened inside the event page and replied to/deleted/resolved.  It is probable that you might get instant feedback on the deletion  because I didn't do the instant mutation of the api call result since its a pain and this is buried well in the back of the site and probably will never be used.

There is a significant change to how commentthreads are added to the dom: they are now added by createportal which means the position of them can be changed at will rather than being embedded in the dom with the thread icon component.


![new_comment_table2](https://github.com/user-attachments/assets/41b255cb-ed0b-43b4-b392-a48ac68094d0)

![image](https://github.com/user-attachments/assets/079b6f02-6cda-40b0-9594-f2d80f4c215b)
The old one ^ is naff:

