### PR TITLE
276 course outcomes

### DIFF
--- a/lib/material.ts
+++ b/lib/material.ts
@@ -45,6 +45,7 @@ export type Course = {
   attribution: Attribution[]
   summary: string
   files: string[][]
+  learningOutcomes: string[]
 }
 
 export type Theme = {
@@ -229,6 +230,8 @@ export async function getCourse(repo: string, theme: string, course: string, no_
   // @ts-expect-error
   const summary = (courseObject.attributes.summary as string) || ""
   // @ts-expect-error
+  const learningOutcomes = (courseObject.attributes.learningOutcomes as string[]) || []
+  // @ts-expect-error
   const dependsOn = (courseObject.attributes.dependsOn as string[]) || []
   const markdown = no_markdown ? "" : (courseObject.body as string)
   // @ts-expect-error
@@ -246,7 +249,7 @@ export async function getCourse(repo: string, theme: string, course: string, no_
   sections = sections.filter((section) => !excludeSections.includes(section.id))
   const type = "Course"
 
-  return { id, theme, name, sections, dependsOn, markdown, type, attribution, summary, files }
+  return { id, theme, name, sections, dependsOn, markdown, type, attribution, summary, files, learningOutcomes }
 }
 
 // https://stackoverflow.com/questions/21792367/replace-underscores-with-spaces-and-capitalize-words

--- a/pages/material/[repoId]/[themeId]/[courseId].tsx
+++ b/pages/material/[repoId]/[themeId]/[courseId].tsx
@@ -11,6 +11,7 @@ import { PageTemplate, pageTemplate } from "lib/pageTemplate"
 import revalidateTimeout from "lib/revalidateTimeout"
 import CourseGrid from "components/navdiagram/CourseGrid"
 import Stack from "components/ui/Stack"
+import LearningOutcomes from "components/content/LearningOutcomes"
 import Link from "next/link"
 import SubTitle from "components/ui/SubTitle"
 
@@ -35,6 +36,7 @@ const CourseComponent: NextPage<CourseComponentProps> = ({
       <Link className="text-blue-500 italic" href={`/material/${theme.repo}/${theme.id}/${course.id}/diagram`}>
         <SubTitle text="View Course Diagram" />
       </Link>
+      <LearningOutcomes learningOutcomes={course.learningOutcomes} />
       <CourseGrid course={course} theme={theme} />
       <Content markdown={course.markdown} theme={theme} course={course} />
     </Layout>


### PR DESCRIPTION
- Adds ability to show course-level outcomes
- Outcomes are entered into the Markdown header with key `learningOutcomes` in the same way as done for Sections
- Resolves #276 