### PR TITLE
build: remove docker compose version

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 x-vol-args: &args
   volumes: 
     - ./.material:/app/.material

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 # Use postgres/example user/password credentials
-version: "3.9"
-
 services:
   nginx:
     image: nginx:${NGINX_IMAGE_TAG} # stable-alpine3.19


### PR DESCRIPTION
Remove `version` key from `docker-compose.yml` and `docker-compose.dev.yml` files.

Fixes:
```sh
docker-compose.dev.yml: the attribute `version` is obsolete, it will be ignored,
please remove it to avoid potential confusion.
```