### PR TITLE
build: docker development build

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,7 +18,7 @@ services:
       - dev-data:/var/lib/postgresql/data
     
   gutenberg:
-    image: gutenberg
+    image: gutenberg-dev
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,11 +22,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: builder
       args: 
         CACHE_BUST: ${CACHE_BUST}
         MATERIAL_METHOD: "pull"
         MATERIAL_DIR: ".material"
         YAML_TEMPLATE: "config/oxford.yaml"
+    command: "yarn dev"
+    volumes:
+      - ./components:/app/components
+      - ./pages:/app/pages
     ports:
       - "3000:3000"
     links: 


### PR DESCRIPTION
Alter `docker-compose.dev.yml` to mount the local `components` and `pages` directories. Run `yarn dev` instead of `yarn start`.

- towards #286.