### PR TITLE
docs: fix broken docker links

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Now everything should be set up for local development of the core systems.
 
 ## Getting started (using Docker-compose)
 
-Gutenberg also has a deployable dev environment using docker-compose. If you wish to use this alternative then see [getting started using docker compose](blog.oxrse.uk/gutenberg/getting-started-docker-compose).
+Gutenberg also has a deployable dev environment using docker-compose. If you wish to use this alternative then see [getting started using docker compose](https://blog.oxrse.uk/gutenberg/development/docker).
 
 ## Developing material
 

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -1,6 +1,6 @@
 ---
 Title: Deploying with Docker-compose
-permalink: /gutenberg/docker
+permalink: /development/docker
 ---
 
 Gutenberg can be deployed both locally and to production using docker-compose.
@@ -20,7 +20,7 @@ cd gutenberg
 From here we can simply run:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 which should make gutenberg available to you at http://localhost:3000. This will
@@ -30,7 +30,7 @@ this might take a few minutes. If you want to force a rebuild after you've made
 some changes you can append the `--build` flag after `up`, i.e.
 
 ```
-docker-compose up --build
+docker compose up --build
 ```
 
 Although this isn't particularly quick. By default the compose setup will pull


### PR DESCRIPTION
Fix the permalink for the Docker docs, and update the README to reflect the new location.