### PR TITLE
docs: update docker development instructions

### DIFF
--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -49,6 +49,7 @@ changes to the code and see them on http://localhost:3000.
 
 ```sh
 # install the course materials locally
+pip install -r scripts/python_requirements.txt
 python scripts/pull_material.py
 # build the development image
 docker compose -f docker-compose.dev.yaml build

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -48,6 +48,8 @@ including Node and Yarn. It runs the app in development mode, so that you can ma
 changes to the code and see them on http://localhost:3000.
 
 ```sh
+# install the course materials locally
+python scripts/pull_material.py
 # build the development image
 docker compose -f docker-compose.dev.yaml build
 # run the Next.js app on http://localhost:3000 in development mode


### PR DESCRIPTION
When you're developing locally with Docker, you need to install the course materials first.