### PR TITLE
fix: run corepack enable in the runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,7 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 COPY --from=builder --chown=nextjs:nextjs /app ./
 COPY ./prisma /app/prisma
+RUN corepack enable
 
 USER nextjs
 


### PR DESCRIPTION
Run `corepack enable` in the Docker `runner` image, to install Yarn 3.

- closes #312.
- I think this will fix the broken staging deploy: https://github.com/OxfordRSE/gutenberg/actions/runs/13203319059/job/36860657015