### PR TITLE
fix: symlink libssl on latest Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,7 @@ RUN yarn build
 
 # Production image, copy all the files and run next
 FROM node:${NODE_VERSION} AS runner
+RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 WORKDIR /app
 RUN apk add --no-cache git
 ENV NODE_ENV production


### PR DESCRIPTION
symlink `libssl` in the runner image on Alpine 3.21, as a workaround for older Prisma clients looking for it in `/lib`.

This fixes an issue for me where the Prisma client errors after building and running the latest Docker image. The app runs, but won't connect to the database.

```bash
gutenberg-1  | prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
gutenberg-1  | Please manually install OpenSSL and try installing Prisma again.
```

- see https://github.com/prisma/prisma/issues/25817.