### PR TITLE
Migrate to self hosted plausible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         run: corepack enable
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: Checkout course material
         shell: bash
         run: |
@@ -30,6 +30,7 @@ jobs:
       - run: flyctl deploy --remote-only
           --build-arg DATABASE_URL=${{secrets.DATABASE_URL}}
           --build-arg NEXT_PUBLIC_PLAUSIBLE_DOMAIN=${{secrets.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}}
+          --build-arg NEXT_PUBLIC_PLAUSIBLE_HOST=${{secrets.NEXT_PUBLIC_PLAUSIBLE_HOST}}
           --wait-timeout 240
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,9 @@ jobs:
       - run: flyctl deploy -a gutenberg-staging --remote-only
           --build-arg DATABASE_URL=${{secrets.DATABASE_URL_TEST}}
           --build-arg NEXT_PUBLIC_PLAUSIBLE_DOMAIN=${{secrets.NEXT_PUBLIC_PLAUSIBLE_DOMAIN_TEST}}
+          --build-arg NEXT_PUBLIC_PLAUSIBLE_HOST=${{secrets.NEXT_PUBLIC_PLAUSIBLE_HOST}}
           --wait-timeout 240
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           NEXT_PUBLIC_PLAUSIBLE_DOMAIN: ${{ secrets.NEXT_PUBLIC_PLAUSIBLE_DOMAIN }}
+          NEXT_PUBLIC_PLAUSIBLE_HOST: ${{ secrets.NEXT_PUBLIC_PLAUSIBLE_HOST }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,13 +78,10 @@ COPY prisma ./prisma
 RUN corepack enable && yarn install --immutable
 COPY . .
 
-# If using npm with a `package-lock.json` comment out above and use below instead
-# RUN npm ci
-
 ENV NEXT_TELEMETRY_DISABLED 1
 
 # Add `ARG` instructions below if you need `NEXT_PUBLIC_` variables
-# then put the value on your fly.toml
+# then put the value on your fly.toml or github secrets
 # Example:
 # ARG NEXT_PUBLIC_EXAMPLE="value here"
 
@@ -96,6 +93,8 @@ ARG DATABASE_URL
 ENV DATABASE_URL ${DATABASE_URL}
 ARG NEXT_PUBLIC_PLAUSIBLE_DOMAIN
 ENV NEXT_PUBLIC_PLAUSIBLE_DOMAIN ${NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
+ARG NEXT_PUBLIC_PLAUSIBLE_HOST
+ENV NEXT_PUBLIC_PLAUSIBLE_HOST ${NEXT_PUBLIC_PLAUSIBLE_HOST}
 
 # Copy the course material into this container for the build
 ARG MATERIAL_DIR=.material

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -21,6 +21,7 @@ import { useTheme } from "next-themes"
 import { ThemeProvider } from "@mui/material/styles"
 import { CssBaseline } from "@mui/material"
 import { LightTheme, DarkTheme } from "./MuiTheme"
+import plausibleHost from "lib/plausibleHost"
 
 type Props = {
   material: Material
@@ -81,6 +82,7 @@ const Layout: React.FC<Props> = ({ material, theme, course, section, children, p
             />
             <PlausibleProvider
               domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN ?? ""}
+              customDomain={plausibleHost}
               enabled={true}
               trackLocalhost={true}
               trackOutboundLinks={true}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 x-vol-args: &args
-  volumes: 
+  volumes:
     - ./.material:/app/.material
 
 services:
@@ -14,19 +14,19 @@ services:
       - "5432:5432"
     volumes:
       - dev-data:/var/lib/postgresql/data
-    
+
   gutenberg:
     image: gutenberg-dev
     build:
       context: .
       dockerfile: Dockerfile
       target: builder
-      args: 
+      args:
         CACHE_BUST: ${CACHE_BUST}
         MATERIAL_METHOD: "pull"
         MATERIAL_DIR: ".material"
         YAML_TEMPLATE: "config/oxford.yaml"
-    command: "yarn dev"
+        NODE_ENV: "development"
     volumes:
       - node-modules:/app/node_modules
       - ./.material:/app/.material
@@ -44,7 +44,7 @@ services:
       - ./tailwind.config.js:/app/tailwind.config.js
     ports:
       - "3000:3000"
-    links: 
+    links:
       - db
     <<: *args
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
         MATERIAL_METHOD: "pull"
         MATERIAL_DIR: ".material"
         YAML_TEMPLATE: "config/oxford.yaml"
+        NODE_ENV: "production"
     links:
       - db
     depends_on:

--- a/docs/config/vars.md
+++ b/docs/config/vars.md
@@ -5,7 +5,7 @@ permalink: /config/vars
 
 This document describes the environment variables used in the project, please set theses as either an env file or as secrets on fly.io.
 
-Note that only NEXT_PUBLIC_ variables are available in the frontend, while other variables are used in the backend.
+Note that only `NEXT_PUBLIC_` variables are available in the frontend, while other variables are used in the backend.
 Since these "public" variables are available in the frontend, they should not contain sensitive information, they are also set at build time and cannot be changed at runtime.
 
 ## Essential

--- a/docs/config/vars.md
+++ b/docs/config/vars.md
@@ -5,6 +5,9 @@ permalink: /config/vars
 
 This document describes the environment variables used in the project, please set theses as either an env file or as secrets on fly.io.
 
+Note that only NEXT_PUBLIC_ variables are available in the frontend, while other variables are used in the backend.
+Since these "public" variables are available in the frontend, they should not contain sensitive information, they are also set at build time and cannot be changed at runtime.
+
 ## Essential
 
 `DATABASE_URL`
@@ -58,4 +61,13 @@ The following variables are used for the search functionality, you need both an 
 `QDRANT_API_KEY`
 : This is the API key for Qdrant, if you have set one in the Qdrant container.
 
-Please replace the placeholder values with your actual values when setting up the environment variables.
+## Analytics
+
+`NEXT_PUBLIC_PLAUSIBLE_DOMAIN`
+: Default: None
+: This is the domain name necessary to use analytics with plausible e.g "train.rse.ox.ac.uk". This might produce build errors due to the way the environment variables are set up, if this happens please set this variable in the github secrets.
+
+`NEXT_PUBLIC_PLAUSIBLE_HOST`
+: Default: "<https://plausible.io>"
+: This is the host for the plausible analytics service. This needs set to your custom domain if you are using a self-hosted version of plausible.
+

--- a/docs/config/vars.md
+++ b/docs/config/vars.md
@@ -70,4 +70,3 @@ The following variables are used for the search functionality, you need both an 
 `NEXT_PUBLIC_PLAUSIBLE_HOST`
 : Default: "<https://plausible.io>"
 : This is the host for the plausible analytics service. This needs set to your custom domain if you are using a self-hosted version of plausible.
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
-# Run migrations on the database
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Run database migrations
 npx prisma migrate deploy
 
-yarn cron &
-yarn start
+# Run different commands based on NODE_ENV
+if [ "$NODE_ENV" = "development" ]; then
+    echo "Running in development mode..."
+    exec yarn dev
+else
+    echo "Running in production mode..."
+    exec yarn cron &
+    exec yarn start
+fi

--- a/lib/plausibleHost.ts
+++ b/lib/plausibleHost.ts
@@ -1,0 +1,2 @@
+const plausibleHost = process.env.NEXT_PUBLIC_PLAUSIBLE_HOST || "https://plausible.io"
+export default plausibleHost


### PR DESCRIPTION
setting the plausible host as a next_public var means we can point it to a custom solution.