### PR TITLE
Dynamic internal links

### DIFF
--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -167,6 +167,12 @@ const Content: React.FC<Props> = ({ markdown, theme, course, section }) => {
     section ? section.id : ""
   }`
   
+  
+  function replaceBaseUrl(markdown: string): string {
+    const baseUrl = `${process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}/material/${theme?.repo}`;
+    return markdown.replace(/\{\{\s*base_url\s*\}\}/g, baseUrl);
+  }
+  
   const transformLink = (href: string): string => {
     if (!href) return href;
     if (href.startsWith('#')) {
@@ -183,6 +189,8 @@ const Content: React.FC<Props> = ({ markdown, theme, course, section }) => {
     const cleanPath = cleanedHref.replace(/^\/+/, '');
     return `/material/${theme?.repo}/${cleanPath}`;
   };
+
+  markdown = replaceBaseUrl(markdown); // we look for {{ base_url }} and replace it with a domain/material/${theme.repo}
 
   return (
     <div className="mx-auto prose prose-base max-w-2xl prose-slate dark:prose-invert prose-pre:bg-[#263E52] px-5">

--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -50,8 +50,8 @@ const isLikelyExternal = (href: string): boolean => {
     /^www\.[^\s]+\.[^\s]+/.test(href) ||
     // Has a domain-like pattern
     /^[^\s]+\.[^\s]+/.test(href)
-  );
-};
+  )
+}
 
 const p = (sectionStr: string) => {
   function p({ node, children, ...props }: ReactMarkdownProps) {
@@ -166,31 +166,30 @@ const Content: React.FC<Props> = ({ markdown, theme, course, section }) => {
   const sectionStr = `${theme ? theme.repo + "." : ""}${theme ? theme.id + "." : ""}${course ? course.id + "." : ""}${
     section ? section.id : ""
   }`
-  
-  
+
   function replaceBaseUrl(markdown: string): string {
-    const baseUrl = `${process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}/material/${theme?.repo}`;
-    return markdown.replace(/\{\{\s*base_url\s*\}\}/g, baseUrl);
+    const baseUrl = `${process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}/material/${theme?.repo}`
+    return markdown.replace(/\{\{\s*base_url\s*\}\}/g, baseUrl)
   }
-  
+
   const transformLink = (href: string): string => {
-    if (!href) return href;
-    if (href.startsWith('#')) {
-      return href; // anchor link — don't rewrite
+    if (!href) return href
+    if (href.startsWith("#")) {
+      return href // anchor link — don't rewrite
     }
 
-    let cleanedHref = href.replace(/\.md$/i, '');
+    let cleanedHref = href.replace(/\.md$/i, "")
 
     if (isLikelyExternal(cleanedHref)) {
-      return cleanedHref.startsWith('http') ? href : `https://${href}`;
+      return cleanedHref.startsWith("http") ? href : `https://${href}`
     }
-  
-    // Treat as internal
-    const cleanPath = cleanedHref.replace(/^\/+/, '');
-    return `/material/${theme?.repo}/${cleanPath}`;
-  };
 
-  markdown = replaceBaseUrl(markdown); // we look for {{ base_url }} and replace it with a domain/material/${theme.repo}
+    // Treat as internal
+    const cleanPath = cleanedHref.replace(/^\/+/, "")
+    return `/material/${theme?.repo}/${cleanPath}`
+  }
+
+  markdown = replaceBaseUrl(markdown) // we look for {{ base_url }} and replace it with a domain/material/${theme.repo}
 
   return (
     <div className="mx-auto prose prose-base max-w-2xl prose-slate dark:prose-invert prose-pre:bg-[#263E52] px-5">
@@ -209,8 +208,8 @@ const Content: React.FC<Props> = ({ markdown, theme, course, section }) => {
           h3: h(sectionStr, "h3"),
           h4: h(sectionStr, "h4"),
           a: ({ node, ...props }) => {
-            const newHref = transformLink(props.href || '');
-            return <a {...props} href={newHref} />;
+            const newHref = transformLink(props.href || "")
+            return <a {...props} href={newHref} />
           },
         }}
       >


### PR DESCRIPTION
This will close #168 

The approach here is two fold, one that in reality we should be using internal paths in anchor links rather than full urls HOWEVER the material pages are hosted on /material/repo/path/to/page which isnt obvious to a course writer (and indeed repo is not known without knowing the config yaml i.e. if a user specifies the repo in the url then it will make the markdown no longer deployment agnostic. The solution I've gone for here thefore detects internal links and prepends /material/repo/

Secondly, for non anchor links this is not possible because we instead have to be replacing text rather than hrefs so we go as suggested in the issue with a {{ base_url }} template identifier and swap that for the domain.com/material/repo/ such that the rest of the link works.

this means the following all resolve correctly:

```
[link](www.train.rse.ox.ac.uk)

[internalLink](high_performance_computing/hpc_intro/01_hpc_intro)

[link with leading slash](/high_performance_computing/hpc_intro/01_hpc_intro)

[link with eroneous .md](high_performance_computing/hpc_intro/01_hpc_intro.md)

Link in text: {{ base_url }}/high_performance_computing/hpc_intro/01_hpc_intro

```python
linkincodeblock = "{{ base_url }}/high_performance_computing/hpc_intro/01_hpc_intro"
```

```

