### PR TITLE
fix: download links are detected as domain names

### DIFF
--- a/components/content/Content.tsx
+++ b/components/content/Content.tsx
@@ -49,7 +49,7 @@ const isLikelyExternal = (href: string): boolean => {
     // Starts with www.
     /^www\.[^\s]+\.[^\s]+/.test(href) ||
     // Has a domain-like pattern
-    /^[^\s]+\.[^\s]+/.test(href)
+    /^[^\s\/]+\.[^\s]+/.test(href)
   )
 }
 


### PR DESCRIPTION
Exclude `/` from domain-like links, so that download links are not matched as external URLs eg. `files/docker-intro.zip`.
- closes #350.