### PR TITLE
feat: unique page titles

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,25 +1,20 @@
 import React from "react"
 import Head from "next/head"
-import { Course, Theme } from "lib/material"
 import { PageTemplate } from "lib/pageTemplate"
-var fs = require("fs")
 
 type Props = {
-  theme?: Theme
-  course?: Course
   pageInfo?: PageTemplate
+  pageTitle?: string
 }
 
 //const style = fs.readFileSync('./node_modules/highlight.js/styles/github.css', "utf8");
 
-const Header: React.FC<Props> = ({ theme, course, pageInfo }) => {
+const Header: React.FC<Props> = ({ pageInfo, pageTitle }) => {
   const logoSrc = pageInfo?.logo.src
-  const logoAlt = pageInfo?.logo.alt
   const description = pageInfo?.description
-  const pageTitle = pageInfo?.title
   return (
     <Head>
-      <title>{pageTitle}</title>
+      <title>{pageTitle || pageInfo?.title}</title>
       {pageInfo && <meta name="description" content={description} />}
       {pageInfo && <link rel="icon" href={logoSrc} />}
     </Head>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,7 +1,6 @@
 import { Course, Section, Theme } from "lib/material"
 import Link from "next/link"
 
-import { useRouter } from "next/router"
 import { useSession } from "next-auth/react"
 import { useState } from "react"
 import React, { ReactNode } from "react"
@@ -19,7 +18,6 @@ import { findLinks } from "lib/findSectionLinks"
 import PlausibleProvider from "next-plausible"
 import { useTheme } from "next-themes"
 import { ThemeProvider } from "@mui/material/styles"
-import { CssBaseline } from "@mui/material"
 import { LightTheme, DarkTheme } from "./MuiTheme"
 import plausibleHost from "lib/plausibleHost"
 
@@ -30,15 +28,25 @@ type Props = {
   section?: Section
   children: ReactNode
   pageInfo?: PageTemplate
+  pageTitle?: string
   repoUrl?: string
   excludes?: Excludes
 }
 
-const Layout: React.FC<Props> = ({ material, theme, course, section, children, pageInfo, repoUrl, excludes }) => {
+const Layout: React.FC<Props> = ({
+  material,
+  theme,
+  course,
+  section,
+  children,
+  pageInfo,
+  pageTitle,
+  repoUrl,
+  excludes,
+}) => {
   const [activeEvent, setActiveEvent] = useActiveEvent()
-  const router = useRouter()
   const { data: session } = useSession()
-  const { systemTheme, theme: currentTheme } = useTheme()
+  const { theme: currentTheme } = useTheme()
   const [showAttribution, setShowAttribution] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useSidebarOpen(true)
   const sectionLinks: SectionLink[] = findLinks(material, theme, course, section, activeEvent)
@@ -51,7 +59,7 @@ const Layout: React.FC<Props> = ({ material, theme, course, section, children, p
           <Link href="#main" className="sr-only focus:not-sr-only">
             Skip to main content
           </Link>
-          <Header theme={theme} course={course} pageInfo={pageInfo} />
+          <Header pageInfo={pageInfo} pageTitle={pageTitle} />
           <header>
             <Navbar
               material={material}

--- a/pages/event/[eventId].tsx
+++ b/pages/event/[eventId].tsx
@@ -193,8 +193,9 @@ const Event: NextPage<EventProps> = ({ material, event, pageInfo }) => {
       </Stack>
     </form>
   )
+  const pageTitle = pageInfo?.title ? `${event.name}: ${pageInfo.title}` : event.name
   return (
-    <Layout material={material} pageInfo={pageInfo}>
+    <Layout material={material} pageInfo={pageInfo} pageTitle={pageTitle}>
       {eventData && isAdmin ? (
         <Tabs.Group style="underline">
           <Tabs.Item active icon={MdPreview} title="Event">

--- a/pages/event/[eventId]/[eventGroupId].tsx
+++ b/pages/event/[eventId]/[eventGroupId].tsx
@@ -301,8 +301,9 @@ const EventGroupPage: NextPage<EventGroupProps> = ({ material, event, eventGroup
     </form>
   )
 
+  const pageTitle = pageInfo?.title ? `${eventGroup.name}: ${pageInfo.title}` : eventGroup.name
   return (
-    <Layout material={material} pageInfo={pageInfo}>
+    <Layout material={material} pageInfo={pageInfo} pageTitle={pageTitle}>
       {isAdmin ? (
         <Tabs.Group style="underline">
           <Tabs.Item active icon={MdPreview} title="Event">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,7 +23,7 @@ const Home: NextPage<HomeProps> = ({ material, events, pageInfo }) => {
 
   const linkClassName = "text-blue-500 hover:underline"
   return (
-    <Layout material={material} pageInfo={pageInfo}>
+    <Layout material={material} pageInfo={pageInfo} pageTitle={pageInfo.title}>
       <div className="px-2 md:px-10 lg:px-10 xl:px-20 2xl:px-32  grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
         <Card className="scroll" style={{ maxHeight: "82vh", overflowY: "auto" }}>
           <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">Course Events</h5>

--- a/pages/material/[repoId]/[themeId].tsx
+++ b/pages/material/[repoId]/[themeId].tsx
@@ -22,8 +22,9 @@ type ThemeComponentProps = {
 }
 
 const ThemeComponent: NextPage<ThemeComponentProps> = ({ theme, material, events, pageInfo, excludes }) => {
+  const pageTitle = pageInfo?.title ? `${theme.name}: ${pageInfo.title}` : theme.name
   return (
-    <Layout material={material} theme={theme} pageInfo={pageInfo}>
+    <Layout material={material} theme={theme} pageInfo={pageInfo} pageTitle={pageTitle}>
       <Title text={theme.name} style={{ marginBottom: "0px" }} />
       <Link className="text-blue-500 italic" href={`/material/${theme.repo}/${theme.id}/diagram`}>
         <SubTitle text="View Theme Diagram" />

--- a/pages/material/[repoId]/[themeId]/[courseId].tsx
+++ b/pages/material/[repoId]/[themeId]/[courseId].tsx
@@ -30,8 +30,9 @@ const CourseComponent: NextPage<CourseComponentProps> = ({
   events,
   pageInfo,
 }: CourseComponentProps) => {
+  const pageTitle = pageInfo?.title ? `${course.name}: ${pageInfo.title}` : course.name
   return (
-    <Layout theme={theme} course={course} material={material} pageInfo={pageInfo}>
+    <Layout theme={theme} course={course} material={material} pageInfo={pageInfo} pageTitle={pageTitle}>
       <Title text={course.name} style={{ marginBottom: "0px" }} />
       <Link className="text-blue-500 italic" href={`/material/${theme.repo}/${theme.id}/${course.id}/diagram`}>
         <SubTitle text="View Course Diagram" />

--- a/pages/material/[repoId]/[themeId]/[courseId]/[sectionId].tsx
+++ b/pages/material/[repoId]/[themeId]/[courseId]/[sectionId].tsx
@@ -41,6 +41,7 @@ const SectionComponent: NextPage<SectionComponentProps> = ({
   repoUrl,
   excludes,
 }: SectionComponentProps) => {
+  const pageTitle = pageInfo?.title ? `${section.name}: ${pageInfo.title}` : section.name
   return (
     <Layout
       theme={theme}
@@ -48,6 +49,7 @@ const SectionComponent: NextPage<SectionComponentProps> = ({
       section={section}
       material={material}
       pageInfo={pageInfo}
+      pageTitle={pageTitle}
       repoUrl={repoUrl}
       excludes={excludes}
     >

--- a/pages/material/index.tsx
+++ b/pages/material/index.tsx
@@ -18,8 +18,9 @@ type HomeProps = {
 }
 
 const Home: NextPage<HomeProps> = ({ material, events, pageInfo }) => {
+  const pageTitle = pageInfo?.title ? `Material Themes: ${pageInfo.title}` : "Material Themes"
   return (
-    <Layout material={material} pageInfo={pageInfo}>
+    <Layout material={material} pageInfo={pageInfo} pageTitle={pageTitle}>
       <Title text="Material Themes" className="text-3xl font-bold text-center p-3" style={{ marginBottom: "0px" }} />
       <Link className="text-blue-500 italic" href={`/material/diagram`}>
         <SubTitle text="view full diagram" />


### PR DESCRIPTION
Add a `pageTitle` prop to the `Layout` component, and use it to set a unique title for each page eg. 'Packaging Python Projects: OxRSE Training.'

- closes #357.