### PR TITLE
fix(a11y): home page heading structure

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,7 @@ import EventsView from "components/EventsView"
 import { pageTemplate, PageTemplate } from "lib/pageTemplate"
 import { Markdown } from "components/content/Content"
 import revalidateTimeout from "lib/revalidateTimeout"
+import Title from "components/ui/Title"
 
 type HomeProps = {
   material: Material
@@ -24,16 +25,17 @@ const Home: NextPage<HomeProps> = ({ material, events, pageInfo }) => {
   const linkClassName = "text-blue-500 hover:underline"
   return (
     <Layout material={material} pageInfo={pageInfo}>
+      <Title text={pageInfo?.title} className="text-3xl font-bold text-center p-3" style={{ marginBottom: "0px" }} />
       <div className="px-2 md:px-10 lg:px-10 xl:px-20 2xl:px-32  grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
         <Card className="scroll" style={{ maxHeight: "82vh", overflowY: "auto" }}>
-          <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">Course Events</h5>
+          <h2 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">Course Events</h2>
           <p className="font-normal text-gray-700 dark:text-gray-400">
             Login to request a place on an upcoming course, or to select an active course.
           </p>
           <EventsView material={material} events={events} />
         </Card>
         <Card className="z-60">
-          <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">Course Material</h5>
+          <h2 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">Course Material</h2>
           <div className="font-normal text-gray-700 dark:text-gray-400">{intro && <Markdown markdown={intro} />}</div>
           <Button href={`${basePath}/material`}>
             <p>View the teaching materials</p>


### PR DESCRIPTION
- add a h1 heading to the home page, with the site title.
- change h5 to h2 so that Course Events and Course Material are subheadings of the main heading.
- closes #355.