### PR TITLE
feat: Added toggle active event/select active event to sidebar

### DIFF
--- a/components/EventSwitcher.tsx
+++ b/components/EventSwitcher.tsx
@@ -5,6 +5,7 @@ import { Select, MenuItem, FormControl, InputLabel, Typography, Box } from "@mui
 import { CheckCircle } from "@mui/icons-material"
 import { SelectChangeEvent } from "@mui/material"
 import { HiSwitchHorizontal } from "react-icons/hi"
+import { GoArrowRight } from "react-icons/go"
 
 const EventSwitcher: React.FC = () => {
   const [editMode, setEditMode] = useState(false)
@@ -23,7 +24,11 @@ const EventSwitcher: React.FC = () => {
   if (isLoading || !events) return null
 
   return (
-    <Box className="px-3 py-2 border-b border-gray-300 dark:border-gray-600">
+    <Box
+      component="section"
+      aria-label="Active event selection"
+      className="px-3 py-2 border-b border-gray-300 dark:border-gray-600"
+    >
       {editMode ? (
         <FormControl fullWidth size="small" variant="outlined">
           <InputLabel id="event-select-label">Select Event</InputLabel>
@@ -33,10 +38,18 @@ const EventSwitcher: React.FC = () => {
             value={activeEvent?.id?.toString() ?? ""}
             onChange={(event: SelectChangeEvent) => {
               const selectedId = Number(event.target.value)
+
+              if (!event.target.value) {
+                setActiveEvent(undefined)
+                setEditMode(false)
+                return
+              }
+
               const selectedEvent = events?.find((e) => e.id === selectedId)
               if (selectedEvent) {
                 setActiveEvent(selectedEvent)
               }
+
               setEditMode(false)
             }}
             onBlur={() => setEditMode(false)}
@@ -65,6 +78,9 @@ const EventSwitcher: React.FC = () => {
                 </MenuItem>
               )
             })}
+            <MenuItem value="" aria-label="Set no active event">
+              <Box className="w-full text-gray-500 dark:text-gray-400 italic">Set no active event</Box>
+            </MenuItem>
           </Select>
         </FormControl>
       ) : (
@@ -72,12 +88,22 @@ const EventSwitcher: React.FC = () => {
           <button
             onClick={() => setEditMode(true)}
             className="text-sm flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+            aria-label={activeEvent ? "Swap active event" : "Select active event"}
           >
-            <HiSwitchHorizontal className="w-4 h-4 mr-1" />
-            <span className="mr-1">Swap</span>
+            {activeEvent ? (
+              <>
+                <HiSwitchHorizontal className="w-4 h-4 mr-1" />
+                <span>Swap</span>
+              </>
+            ) : (
+              <>
+                <GoArrowRight className="w-4 h-4 mr-1" />
+                <span>Select</span>
+              </>
+            )}
           </button>
           <Typography variant="h6" className="truncate text-gray-800 dark:text-gray-400 text-light">
-            {activeEvent?.name ?? "No Active Event"}
+            {activeEvent?.name ?? ""}
           </Typography>
         </Box>
       )}

--- a/components/EventSwitcher.tsx
+++ b/components/EventSwitcher.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react"
+import { useMyEvents } from "lib/hooks/useMyEvents"
+import useActiveEvent from "lib/hooks/useActiveEvents"
+import { Select, MenuItem, FormControl, InputLabel, Typography, Box } from "@mui/material"
+import { CheckCircle } from "@mui/icons-material"
+import { SelectChangeEvent } from "@mui/material"
+import { HiSwitchHorizontal } from "react-icons/hi"
+
+const EventSwitcher: React.FC = () => {
+  const [editMode, setEditMode] = useState(false)
+  const { events, isLoading } = useMyEvents()
+  const [activeEvent, setActiveEvent] = useActiveEvent()
+
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    const selectedId = Number(event.target.value)
+    const selectedEvent = events?.find((e) => e.id === selectedId)
+    if (selectedEvent) {
+      setActiveEvent(selectedEvent)
+    }
+    setEditMode(false)
+  }
+
+  if (isLoading || !events) return null
+
+  return (
+    <Box className="px-3 py-2 border-b border-gray-300 dark:border-gray-600">
+      {editMode ? (
+        <FormControl fullWidth size="small" variant="outlined">
+          <InputLabel id="event-select-label">Select Event</InputLabel>
+          <Select
+            labelId="event-select-label"
+            label="Select Active Event"
+            value={activeEvent?.id?.toString() ?? ""}
+            onChange={(event: SelectChangeEvent) => {
+              const selectedId = Number(event.target.value)
+              const selectedEvent = events?.find((e) => e.id === selectedId)
+              if (selectedEvent) {
+                setActiveEvent(selectedEvent)
+              }
+              setEditMode(false)
+            }}
+            onBlur={() => setEditMode(false)}
+            autoFocus
+            sx={{
+              backgroundColor: "background.paper",
+              color: "text.primary",
+            }}
+          >
+            {events.map((event) => {
+              const date = new Date(event.start).toLocaleDateString(undefined, {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+              })
+              const isSelected = event.id === activeEvent?.id
+
+              return (
+                <MenuItem key={event.id} value={event.id}>
+                  <Box className="flex justify-between items-center w-full">
+                    <Typography>
+                      {event.name} — {date}
+                    </Typography>
+                    {isSelected && <CheckCircle className="text-green-500 ml-2" fontSize="small" />}
+                  </Box>
+                </MenuItem>
+              )
+            })}
+          </Select>
+        </FormControl>
+      ) : (
+        <Box className="flex items-center gap-2">
+          <button
+            onClick={() => setEditMode(true)}
+            className="text-sm flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            <HiSwitchHorizontal className="w-4 h-4 mr-1" />
+            <span className="mr-1">Swap</span>
+          </button>
+          <Typography variant="h6" className="truncate text-gray-800 dark:text-gray-400 text-light">
+            {activeEvent?.name ?? "No Active Event"}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default EventSwitcher

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -57,7 +57,8 @@ const Navbar: React.FC<Props> = ({
   const windowSize = useWindowSize()
   const breakpoint = 900
   const burgerDrawerMaterialMargin = "ml-9"
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
+  const isLoggedIn = status === "authenticated"
   const ref1 = useRef<HTMLLIElement>(null)
   const ref2 = useRef<HTMLLIElement>(null)
   const ref3 = useRef<HTMLLIElement>(null)
@@ -122,6 +123,7 @@ const Navbar: React.FC<Props> = ({
   const toggleDrawer = (open: boolean) => {
     setDrawerOpen(open)
   }
+  console.log(isLoggedIn)
 
   return (
     // remove width !
@@ -130,7 +132,7 @@ const Navbar: React.FC<Props> = ({
       {(windowSize.width ?? 1024) >= 1024 ? (
         <nav className="w-full inline-flex" aria-label="Breadcrumb">
           <ol className="z-10 list-none inline-flex items-center space-x-1 md:space-x-3">
-            {activeEvent && (
+            {isLoggedIn && (
               <>
                 <HiCalendar
                   className="pointer-events-auto cursor-pointer text-gray-500 hover:text-gray-400 w-10 h-10"

--- a/components/Overlay.tsx
+++ b/components/Overlay.tsx
@@ -15,6 +15,7 @@ import { Stack } from "@mui/material"
 import useWindowSize from "lib/hooks/useWindowSize"
 import DeleteUserOnEventModal, { deleteUserOnEventModalState } from "./dialogs/deleteUserOnEventModal"
 import TableOfContents from "./TableOfContents"
+import { useSession } from "next-auth/react"
 
 interface Props {
   material: Material
@@ -47,6 +48,8 @@ const Overlay: NextPage<Props> = ({
   const [showDuplicateEventModal, setShowDuplicateEventModal] = useAtom(duplicateEventModalState)
   const [showDeleteUserOnEventModal, setShowDeleteUserOnEventModal] = useAtom(deleteUserOnEventModalState)
   const windowSize = useWindowSize()
+  const { data: session, status } = useSession()
+  const isLoggedIn = status === "authenticated"
   // remove duplicate links in case activeevent includes the same section as dependsOn, reverse so AE comes first
   sectionLinks = sectionLinks
     ?.filter((item, index, array) => array.findIndex((other) => other.url === item.url) === index)
@@ -90,11 +93,11 @@ const Overlay: NextPage<Props> = ({
   }
   const sectionTitle = section ? section.name : ""
   const attribution = section ? section.attribution : course ? course.attribution : []
-
+  console.log(isLoggedIn, status, session)
   return (
     <div className="z-10 pointer-events-none fixed top-0 container mx-auto">
       <div className="pointer-events-none h-screen w-full flex-col content-between">
-        {activeEvent && showTopButtons && (
+        {isLoggedIn && showTopButtons && (
           <HiCalendar
             className="pointer-events-auto absolute top-0 left-0 cursor-pointer opacity-50 text-gray-600 hover:text-gray-500 w-12 h-12"
             onClick={handleToggle}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -4,7 +4,6 @@ import type { EventFull } from "lib/types"
 import EventSwitcher from "./EventSwitcher"
 import { Fetcher } from "swr"
 import EventView from "./EventView"
-import { HiXCircle } from "react-icons/hi"
 import { MdKeyboardArrowLeft } from "react-icons/md"
 
 type SidebarProps = {
@@ -49,11 +48,17 @@ const MySidebar: React.FC<SidebarProps> = ({ material, activeEvent, sidebarOpen,
 
   return (
     <>
-      {sidebarOpen && activeEvent ? (
+      {sidebarOpen && (
         <div className="pointer-events-auto fixed top-0 pl-2 h-screen overflow-x-hidden border top-15 left-0 text-gray-700 border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700 w-96">
           <div id="sidebar" ref={sidebarRef} className="p-1 overflow-y-auto h-full">
             <EventSwitcher />
-            <EventView material={material} event={activeEvent} />
+
+            {activeEvent ? (
+              <EventView material={material} event={activeEvent} />
+            ) : (
+              <div className="text-center text-sm text-gray-500 dark:text-gray-400 mt-4">No active event selected</div>
+            )}
+
             <button
               onClick={handleClose}
               aria-label="Close sidebar"
@@ -63,8 +68,6 @@ const MySidebar: React.FC<SidebarProps> = ({ material, activeEvent, sidebarOpen,
             </button>
           </div>
         </div>
-      ) : (
-        activeEvent && <div className="fixed top-15 left-0 m-2"></div>
       )}
     </>
   )

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,15 +1,11 @@
-import React, { useEffect, useRef, useState } from "react"
-import Image from "next/image"
+import React, { useEffect, useRef } from "react"
 import { Material } from "lib/material"
-import { Event, EventFull } from "lib/types"
-import { basePath } from "lib/basePath"
-import useSWR, { Fetcher } from "swr"
-import { Button, Sidebar } from "flowbite-react"
+import type { EventFull } from "lib/types"
+import EventSwitcher from "./EventSwitcher"
+import { Fetcher } from "swr"
 import EventView from "./EventView"
-import EventsView from "./EventsView"
-import { MdClose } from "react-icons/md"
-import { HiArrowNarrowRight, HiCalendar, HiMenuAlt1, HiXCircle } from "react-icons/hi"
-import { HiArrowNarrowLeft } from "react-icons/hi"
+import { HiXCircle } from "react-icons/hi"
+import { MdKeyboardArrowLeft } from "react-icons/md"
 
 type SidebarProps = {
   material: Material
@@ -54,13 +50,17 @@ const MySidebar: React.FC<SidebarProps> = ({ material, activeEvent, sidebarOpen,
   return (
     <>
       {sidebarOpen && activeEvent ? (
-        <div className="pointer-events-auto fixed top-0 pl-2 h-screen overflow-x-hidden rounded border top-15 left-0 text-gray-700 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700 w-96">
-          <HiXCircle
-            className="absolute top-1 right-2 z-50 text-gray-500 hover:text-gray-400 opacity-50 w-10 h-10"
-            onClick={handleClose}
-          />
+        <div className="pointer-events-auto fixed top-0 pl-2 h-screen overflow-x-hidden border top-15 left-0 text-gray-700 border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700 w-96">
           <div id="sidebar" ref={sidebarRef} className="p-1 overflow-y-auto h-full">
+            <EventSwitcher />
             <EventView material={material} event={activeEvent} />
+            <button
+              onClick={handleClose}
+              aria-label="Close sidebar"
+              className="absolute top-1 right-0 z-50 text-gray-500 hover:text-gray-400 opacity-50 w-10 h-10"
+            >
+              <MdKeyboardArrowLeft className="w-full h-full" />
+            </button>
           </div>
         </div>
       ) : (

--- a/lib/hooks/useActiveEvents.ts
+++ b/lib/hooks/useActiveEvents.ts
@@ -1,8 +1,4 @@
 import { useState, useEffect, useContext, useCallback } from "react"
-import { basePath } from "lib/basePath"
-import { useSession } from "next-auth/react"
-import { data } from "cypress/types/jquery"
-import { User } from "@prisma/client"
 import { EventFull, Event } from "lib/types"
 import useEvent from "./useEvent"
 import { AppContext } from "lib/context/ContextProvider"


### PR DESCRIPTION
Currently, you can only view the sidebar when on an active event because the sidebars pure prupose is to show the Event details, material covered etc.

This adds a new feature to the sidebar by letting you swap events, especially useful for instructors:

![sidebar_swap](https://github.com/user-attachments/assets/0aaa3d61-fb70-46f5-829c-586b730e19f3)

Also, now the sidebar toggle button is always there rather than just when you are on an active event so you can now select an event on any page:

![sidebar_select](https://github.com/user-attachments/assets/89d2e52f-643e-4b30-850a-b73263f8e19b)


