### PR TITLE
Remove NEXT_PUBLIC_MATERIAL_URL environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,6 @@
 
 MATERIAL_DIR=".material"
 YAML_TEMPLATE="config/oxford.yaml"
-NEXT_PUBLIC_MATERIAL_URL="https://github.com/UNIVERSE-HPC/course-material"
 NEXT_PUBLIC_BASEPATH=""
 NEXTAUTH_URL=http://localhost/api/auth
 NEXTAUTH_SECRET="secret here"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ so you'll be guaranteed to have working versions of each dependency.
 Gutenberg separates its source material from its rendering engine by design.
 This means you need to copy some source material before you have anything to display!
 
-The HPC materials are already listed as a source via the `NEXT_PUBLIC_MATERIAL_URL` variable in the `.env` file.
+The HPC materials are already listed as a source under `material` in the configuration yaml file in the `config` directory.
 
 To download those materials, so we have something to work with, run `yarn pullmat` and they will be cloned into
 a local `.materials` directory.

--- a/docs/config/vars.md
+++ b/docs/config/vars.md
@@ -20,10 +20,6 @@ Since these "public" variables are available in the frontend, they should not co
 `YAML_TEMPLATE`
 : This is the path to the YAML template file. This should be laid out as described [in the template configuration page]({{ "/config/template" | relative_url }}).
 
-`NEXT_PUBLIC_MATERIAL_URL`
-: Default: `https://github.com/UNIVERSE-HPC/course-material`
-: This is the URL where the course material is hosted.
-
 `NEXT_PUBLIC_BASEPATH`
 : Default: `""`
 : This is the base path for the application.


### PR DESCRIPTION
Removes the variable from .env, and the description in docs.
Updates README with the newer material location in the config yaml.
Closes #322.

I have tested installing locally with this removed (not using docker) and there didn't seem to be any issue with the download of material / deployment.