### PR TITLE
feat: move to standalone next build / upgrade to node 24

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/jod
+lts/krypton

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ x-vol-args: &args
 
 services:
   db:
-    image: postgres
+    image: postgres:17
     restart: always
     shm_size: 128mb
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,13 @@ services:
       - NGINX_HOST=localhost
       - NGINX_PORT=8080
       - NGINX_PROXY_PASS=http://gutenberg:3000
+    restart: always
     depends_on:
       gutenberg:
         condition: service_started
 
   db:
-    image: postgres
+    image: postgres:17
     restart: always
     shm_size: 128mb
     environment:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,8 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-# Run database migrations
-npx prisma migrate deploy
+# Run database migrations using globally installed @prisma/migrate
+prisma migrate deploy
 
 # Run different commands based on NODE_ENV
 if [ "$NODE_ENV" = "development" ]; then
@@ -12,6 +12,8 @@ if [ "$NODE_ENV" = "development" ]; then
     exec yarn dev
 else
     echo "Running in production mode..."
-    exec yarn cron &
-    exec yarn start
+    # Run cron with globally installed tsx and dotenv-cli (from app root)
+    dotenv -e .env.local -e .env -- tsx scripts/cronScripts.ts &
+    # The standalone build expects to be run from where the .next dir is
+    cd /app && exec node server.js
 fi

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ import { withPlausibleProxy } from "next-plausible"
 import plausibleHost from "./lib/plausibleHost.js"
 
 const nextConfig = {
+  output: "standalone",
   reactStrictMode: true,
   trailingSlash: false,
   logging: {


### PR DESCRIPTION
closes #304 

closes #426 

This was not clean, the original build size of gutenberg image was 2.7GB

A next standalone build is more like 700, which is awesome cause the material is 356mB currently, so half of the size is just the material repo

However...we hit several blocking issues that had to be worked around:

1. we need prisma to run migrations - this is a total pain, it pulls in 350 megs into the image, it is not possible to use the dedicated migrate package, it does not work for us.

What the dream future would be is that we run migrations on the CI, we make a dedicated container for it and deploy process is to deploy the migration container, migrate and then deploy the real container, or we directly ssh to the machine and run migrate....this is however stupid to do on fly we don't not gain anything from shrinking the container really.... if we hosted gutenberg on AWS then that would be a different story... dunno ill open a follow up but it is not urgent.

2. we need at least some pacakges to run the cron jobs, this can not be avoided.

This means we need to install cron/js-yaml/simple-git and typescript unfortunately... ah well