### PR TITLE
fix: request enrolment button to work with new enrolwithkey api route

### DIFF
--- a/cypress/e2e/landing-page-non-admin.cy.js
+++ b/cypress/e2e/landing-page-non-admin.cy.js
@@ -77,4 +77,19 @@ describe("non admin landing page", () => {
     // Then we remove the user just in case we want to run this test again locally
     cy.request("DELETE", "/api/userOnEvent/1", userOnEvent)
   })
+
+  it("Can Request Enrolment Without Key", () => {
+    cy.get('[data-cy="load-more-events"]').click()
+    cy.get('[data-cy="event-enrol-1"]').should("be.visible")
+    cy.get('[data-cy="event-enrol-1"]').click()
+    cy.get('[data-cy="request-enrol-1"]').should("be.visible")
+    cy.get('[data-cy="request-enrol-1"]').click()
+    cy.contains("Enrollment request sent.").should("be.visible")
+    cy.request("GET", "/api/userOnEvent/1").then((response) => {
+      const uOnE = response.body.userOnEvent
+      expect(uOnE.status).to.equal("REQUEST")
+    })
+    // Then we remove the user just in case we want to run this test again locally
+    cy.request("DELETE", "/api/userOnEvent/1", userOnEvent)
+  })
 })

--- a/pages/api/event/[eventId]/enrol.ts
+++ b/pages/api/event/[eventId]/enrol.ts
@@ -46,8 +46,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       })
     }
     nextStatus = EventStatus.REQUEST
-  }
-  else if (normalizedKey === event.enrolKey) nextStatus = EventStatus.STUDENT
+  } else if (normalizedKey === event.enrolKey) nextStatus = EventStatus.STUDENT
   else if (normalizedKey === event.instructorKey) nextStatus = EventStatus.INSTRUCTOR
   else return res.status(400).json({ error: "Invalid enrolment key" })
 


### PR DESCRIPTION
enrolWithKey was a new api route done to handle enrolments rather than them being done as puts to useronevent or something, I added guards to prevent people hitting this enrolment endpoint without a key (hence the name) thereby i totally broke enrolment without a key (i.e. the request enrolment button)

