### PR TITLE
feat: improve stats pages - sortable columns, total solved, scroll fix

### DIFF
--- a/components/ui/SortableTable.tsx
+++ b/components/ui/SortableTable.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useMemo } from "react"
+import { Table } from "flowbite-react"
+
+type SortDirection = "asc" | "desc"
+
+export type Column<T> = {
+  key: string
+  label: string
+  sortable?: boolean
+  getValue: (row: T) => string | number | null
+  render: (row: T) => React.ReactNode
+  headCellClassName?: string
+  cellClassName?: string
+}
+
+type Props<T> = {
+  columns: Column<T>[]
+  data: T[]
+  rowKey: (row: T) => string
+  defaultSort?: { key: string; direction: SortDirection }
+  dataCy?: string
+  tableClassName?: string
+  wrapperClassName?: string
+}
+
+function SortableTable<T>({ columns, data, rowKey, defaultSort, dataCy, tableClassName, wrapperClassName }: Props<T>) {
+  const [sortKey, setSortKey] = useState(defaultSort?.key ?? "")
+  const [sortDir, setSortDir] = useState<SortDirection>(defaultSort?.direction ?? "desc")
+
+  const handleSort = (key: string) => {
+    if (sortKey === key) {
+      if (sortDir === "desc") {
+        setSortDir("asc")
+      } else {
+        setSortKey("")
+      }
+    } else {
+      setSortKey(key)
+      setSortDir("desc")
+    }
+  }
+
+  const sortedData = useMemo(() => {
+    const col = columns.find((c) => c.key === sortKey)
+    if (!col || !col.sortable) return data
+    return [...data].sort((a, b) => {
+      const aVal = col.getValue(a)
+      const bVal = col.getValue(b)
+      if (aVal === null && bVal === null) return 0
+      if (aVal === null) return 1
+      if (bVal === null) return -1
+      const cmp = typeof aVal === "string" ? aVal.localeCompare(bVal as string) : (aVal as number) - (bVal as number)
+      return sortDir === "asc" ? cmp : -cmp
+    })
+  }, [data, sortKey, sortDir, columns])
+
+  return (
+    <div className={wrapperClassName ?? "mt-3 overflow-x-auto"}>
+      <Table data-cy={dataCy} className={tableClassName}>
+        <Table.Head>
+          {columns.map((col) => (
+            <Table.HeadCell
+              key={col.key}
+              className={`${col.headCellClassName ?? ""} ${col.sortable ? "cursor-pointer select-none hover:bg-gray-100 dark:hover:bg-gray-700" : ""}`.trim()}
+              onClick={col.sortable ? () => handleSort(col.key) : undefined}
+            >
+              <span className="inline-flex items-center gap-1">
+                {col.label}
+                {col.sortable && (
+                  <span className={`text-xs ${sortKey === col.key ? "" : "opacity-30"}`}>
+                    {sortKey === col.key ? (sortDir === "asc" ? "▲" : "▼") : "⇅"}
+                  </span>
+                )}
+              </span>
+            </Table.HeadCell>
+          ))}
+        </Table.Head>
+        <Table.Body className="divide-y">
+          {sortedData.map((row) => (
+            <Table.Row key={rowKey(row)}>
+              {columns.map((col) => (
+                <Table.Cell key={col.key} className={col.cellClassName}>
+                  {col.render(row)}
+                </Table.Cell>
+              ))}
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  )
+}
+
+export default SortableTable

--- a/pages/courses/[courseId]/stats.tsx
+++ b/pages/courses/[courseId]/stats.tsx
@@ -1,12 +1,13 @@
 import type { GetServerSideProps, NextPage } from "next"
 import Link from "next/link"
-import { Button, Table } from "flowbite-react"
+import { Button } from "flowbite-react"
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "pages/api/auth/[...nextauth]"
 import prisma from "lib/prisma"
 import Layout from "components/Layout"
 import Title from "components/ui/Title"
 import StatCard from "components/ui/StatCard"
+import SortableTable, { Column } from "components/ui/SortableTable"
 import { Material, getMaterial, removeMarkdown } from "lib/material"
 import { makeSerializable } from "lib/utils"
 import { loadPageTemplate, PageTemplate } from "lib/pageTemplate"
@@ -35,6 +36,23 @@ const progressBandLabels: Record<keyof CourseStats["progressBands"], string> = {
 }
 
 const CourseStatsDetailPage: NextPage<CourseStatsDetailPageProps> = ({ material, pageInfo, courseStats }) => {
+  const totalProblemsSolved = courseStats.learners.reduce((sum, l) => sum + l.completedProblems, 0)
+  const totalProblemsAvailable = courseStats.learners.reduce((sum, l) => sum + l.totalProblems, 0)
+
+  const sectionColumns: Column<(typeof courseStats.sections)[number]>[] = [
+    { key: "title", label: "Section", sortable: true, getValue: (s) => s.title, render: (s) => s.url ? <Link href={s.url} className="hover:underline">{s.title}</Link> : s.title },
+    { key: "problems", label: "Problems", sortable: true, getValue: (s) => s.totalProblems, render: (s) => s.totalProblems },
+    { key: "avgCompletion", label: "Avg completion", sortable: true, getValue: (s) => s.averageCompletionPercent, render: (s) => formatPercent(s.averageCompletionPercent) },
+    { key: "fullyComplete", label: "Fully complete", sortable: true, getValue: (s) => s.fullyCompletedLearners, render: (s) => s.fullyCompletedLearners },
+  ]
+
+  const learnerColumns: Column<(typeof courseStats.learners)[number]>[] = [
+    { key: "user", label: "User", sortable: true, getValue: (l) => l.userName || l.userEmail, cellClassName: "px-2 py-2", headCellClassName: "px-2 py-2", render: (l) => (<><div className="font-medium leading-tight text-gray-900 dark:text-white">{l.userName || l.userEmail}</div><div className="text-xs leading-tight text-gray-500 dark:text-gray-400">{l.userEmail}</div></>) },
+    { key: "status", label: "Status", sortable: true, getValue: (l) => l.status, cellClassName: "px-2 py-2 whitespace-nowrap", headCellClassName: "px-2 py-2", render: (l) => l.status },
+    { key: "dates", label: "Dates", sortable: true, getValue: (l) => l.startedAt ? new Date(l.startedAt).getTime() : 0, cellClassName: "px-2 py-2 text-xs leading-tight whitespace-nowrap", headCellClassName: "px-2 py-2", render: (l) => (<><div><span className="font-medium text-gray-700 dark:text-gray-300">Start:</span> {formatDate(l.startedAt)}</div><div><span className="font-medium text-gray-700 dark:text-gray-300">Done:</span> {formatDate(l.completedAt)}</div></>) },
+    { key: "progress", label: "Progress", sortable: true, getValue: (l) => l.completionPercent, cellClassName: "px-2 py-2 whitespace-nowrap", headCellClassName: "px-2 py-2", render: (l) => formatPercent(l.completionPercent) },
+    { key: "problems", label: "Problems", sortable: true, getValue: (l) => l.completedProblems, cellClassName: "px-2 py-2 whitespace-nowrap", headCellClassName: "px-2 py-2", render: (l) => l.totalProblems > 0 ? `${l.completedProblems}/${l.totalProblems}` : "N/A" },
+  ]
   const breadcrumbs: BreadcrumbItem[] = [
     { label: "Courses", href: "/courses" },
     { label: "Stats", href: "/courses/stats" },
@@ -96,104 +114,52 @@ const CourseStatsDetailPage: NextPage<CourseStatsDetailPageProps> = ({ material,
             value={courseStats.trackableProblems}
             dataCy="course-detail-stats-trackable-problems"
           />
+          <StatCard
+            label="Total problems solved"
+            value={`${totalProblemsSolved}/${totalProblemsAvailable}`}
+            dataCy="course-detail-stats-total-solved"
+          />
         </div>
 
         <div className="mt-8 grid grid-cols-1 gap-6 xl:grid-cols-2">
           <div>
             <Title text="Progress Bands" className="text-2xl font-bold" style={{ marginBottom: "0px" }} />
             <div className="mt-3 overflow-x-auto">
-              <Table data-cy="course-progress-bands-table">
-                <Table.Head>
-                  <Table.HeadCell>Band</Table.HeadCell>
-                  <Table.HeadCell>Learners</Table.HeadCell>
-                </Table.Head>
-                <Table.Body className="divide-y">
-                  {Object.entries(courseStats.progressBands).map(([band, count]) => (
-                    <Table.Row key={band}>
-                      <Table.Cell>{progressBandLabels[band as keyof CourseStats["progressBands"]]}</Table.Cell>
-                      <Table.Cell>{count}</Table.Cell>
-                    </Table.Row>
-                  ))}
-                </Table.Body>
-              </Table>
+              <SortableTable
+                columns={[
+                  { key: "band", label: "Band", sortable: false, getValue: (b) => b.label, render: (b) => b.label },
+                  { key: "count", label: "Learners", sortable: true, getValue: (b) => b.count, render: (b) => b.count },
+                ]}
+                data={Object.entries(courseStats.progressBands).map(([band, count]) => ({ band, label: progressBandLabels[band as keyof CourseStats["progressBands"]], count }))}
+                rowKey={(b) => b.band}
+                dataCy="course-progress-bands-table"
+                wrapperClassName="overflow-x-auto"
+              />
             </div>
           </div>
 
           <div>
             <Title text="Sections" className="text-2xl font-bold" style={{ marginBottom: "0px" }} />
-            <div className="mt-3 overflow-x-auto">
-              <Table data-cy="course-section-stats-table">
-                <Table.Head>
-                  <Table.HeadCell>Section</Table.HeadCell>
-                  <Table.HeadCell>Problems</Table.HeadCell>
-                  <Table.HeadCell>Avg completion</Table.HeadCell>
-                  <Table.HeadCell>Fully complete</Table.HeadCell>
-                </Table.Head>
-                <Table.Body className="divide-y">
-                  {courseStats.sections.map((section) => (
-                    <Table.Row key={section.sectionRef}>
-                      <Table.Cell>
-                        {section.url ? (
-                          <Link href={section.url} className="hover:underline">
-                            {section.title}
-                          </Link>
-                        ) : (
-                          section.title
-                        )}
-                      </Table.Cell>
-                      <Table.Cell>{section.totalProblems}</Table.Cell>
-                      <Table.Cell>{formatPercent(section.averageCompletionPercent)}</Table.Cell>
-                      <Table.Cell>{section.fullyCompletedLearners}</Table.Cell>
-                    </Table.Row>
-                  ))}
-                </Table.Body>
-              </Table>
-            </div>
+            <SortableTable
+              columns={sectionColumns}
+              data={courseStats.sections}
+              rowKey={(s) => s.sectionRef}
+              dataCy="course-section-stats-table"
+              wrapperClassName="mt-3 max-h-[600px] overflow-y-auto overflow-x-auto"
+            />
           </div>
         </div>
 
         <div className="mt-8">
           <Title text="Learners" className="text-2xl font-bold" style={{ marginBottom: "0px" }} />
-          <div className="mt-3 overflow-x-auto">
-            <Table data-cy="course-learner-stats-table" className="text-sm">
-              <Table.Head>
-                <Table.HeadCell className="px-2 py-2">User</Table.HeadCell>
-                <Table.HeadCell className="px-2 py-2">Status</Table.HeadCell>
-                <Table.HeadCell className="px-2 py-2">Dates</Table.HeadCell>
-                <Table.HeadCell className="px-2 py-2">Progress</Table.HeadCell>
-                <Table.HeadCell className="px-2 py-2">Problems</Table.HeadCell>
-              </Table.Head>
-              <Table.Body className="divide-y">
-                {courseStats.learners.map((learner) => (
-                  <Table.Row key={`${learner.userEmail}-${learner.status}`}>
-                    <Table.Cell className="px-2 py-2">
-                      <div className="font-medium leading-tight text-gray-900 dark:text-white">
-                        {learner.userName || learner.userEmail}
-                      </div>
-                      <div className="text-xs leading-tight text-gray-500 dark:text-gray-400">{learner.userEmail}</div>
-                    </Table.Cell>
-                    <Table.Cell className="px-2 py-2 whitespace-nowrap">{learner.status}</Table.Cell>
-                    <Table.Cell className="px-2 py-2 text-xs leading-tight whitespace-nowrap">
-                      <div>
-                        <span className="font-medium text-gray-700 dark:text-gray-300">Start:</span>{" "}
-                        {formatDate(learner.startedAt)}
-                      </div>
-                      <div>
-                        <span className="font-medium text-gray-700 dark:text-gray-300">Done:</span>{" "}
-                        {formatDate(learner.completedAt)}
-                      </div>
-                    </Table.Cell>
-                    <Table.Cell className="px-2 py-2 whitespace-nowrap">
-                      {formatPercent(learner.completionPercent)}
-                    </Table.Cell>
-                    <Table.Cell className="px-2 py-2 whitespace-nowrap">
-                      {learner.totalProblems > 0 ? `${learner.completedProblems}/${learner.totalProblems}` : "N/A"}
-                    </Table.Cell>
-                  </Table.Row>
-                ))}
-              </Table.Body>
-            </Table>
-          </div>
+          <SortableTable
+            columns={learnerColumns}
+            data={courseStats.learners}
+            rowKey={(l) => `${l.userEmail}-${l.status}`}
+            dataCy="course-learner-stats-table"
+            tableClassName="text-sm"
+            defaultSort={{ key: "progress", direction: "desc" }}
+          />
         </div>
       </div>
     </Layout>

--- a/pages/courses/stats.tsx
+++ b/pages/courses/stats.tsx
@@ -1,12 +1,13 @@
 import type { GetServerSideProps, NextPage } from "next"
 import Link from "next/link"
-import { Badge, Button, Table } from "flowbite-react"
+import { Badge, Button } from "flowbite-react"
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "pages/api/auth/[...nextauth]"
 import prisma from "lib/prisma"
 import Layout from "components/Layout"
 import Title from "components/ui/Title"
 import StatCard from "components/ui/StatCard"
+import SortableTable, { Column } from "components/ui/SortableTable"
 import { Material, getMaterial, removeMarkdown } from "lib/material"
 import { makeSerializable } from "lib/utils"
 import { loadPageTemplate, PageTemplate } from "lib/pageTemplate"
@@ -30,9 +31,17 @@ type CourseStatsPageProps = {
 const breadcrumbs: BreadcrumbItem[] = [{ label: "Courses", href: "/courses" }, { label: "Stats" }]
 
 const CourseStatsPage: NextPage<CourseStatsPageProps> = ({ material, pageInfo, overview, courseStats }) => {
-  const sortedCourses = [...courseStats].sort(
-    (a, b) => b.totalLearners - a.totalLearners || a.name.localeCompare(b.name)
-  )
+  const courseColumns: Column<CourseStats>[] = [
+    { key: "name", label: "Course", sortable: true, getValue: (c) => c.name, render: (c) => (<><Link href={`/courses/${c.courseId}/stats`} className="hover:underline font-medium text-gray-900 dark:text-white">{c.name}</Link>{c.hidden && <Badge color="gray" className="ml-2 inline-flex">Hidden</Badge>}</>) },
+    { key: "level", label: "Level", sortable: true, getValue: (c) => c.level || "", render: (c) => c.level || "N/A" },
+    { key: "people", label: "People", sortable: true, getValue: (c) => c.totalLearners, render: (c) => c.totalLearners },
+    { key: "inProgress", label: "In progress", sortable: true, getValue: (c) => c.enrolledCount, render: (c) => c.enrolledCount },
+    { key: "completed", label: "Completed", sortable: true, getValue: (c) => c.completedCount, render: (c) => c.completedCount },
+    { key: "dropped", label: "Dropped", sortable: true, getValue: (c) => c.droppedCount, render: (c) => c.droppedCount },
+    { key: "completionRate", label: "Completion rate", sortable: true, getValue: (c) => c.completionRate, render: (c) => formatPercent(c.completionRate) },
+    { key: "avgCompletion", label: "Avg completion", sortable: true, getValue: (c) => c.averageCompletionDays, render: (c) => formatDays(c.averageCompletionDays) },
+    { key: "avgProgress", label: "Avg progress", sortable: true, getValue: (c) => c.averageProgressPercent, render: (c) => formatPercent(c.averageProgressPercent) },
+  ]
 
   return (
     <Layout
@@ -89,45 +98,13 @@ const CourseStatsPage: NextPage<CourseStatsPageProps> = ({ material, pageInfo, o
 
         <div className="mt-8">
           <Title text="By Course" className="text-2xl font-bold" style={{ marginBottom: "0px" }} />
-          <div className="mt-3 overflow-x-auto">
-            <Table data-cy="course-stats-table">
-              <Table.Head>
-                <Table.HeadCell>Course</Table.HeadCell>
-                <Table.HeadCell>Level</Table.HeadCell>
-                <Table.HeadCell>People</Table.HeadCell>
-                <Table.HeadCell>In progress</Table.HeadCell>
-                <Table.HeadCell>Completed</Table.HeadCell>
-                <Table.HeadCell>Dropped</Table.HeadCell>
-                <Table.HeadCell>Completion rate</Table.HeadCell>
-                <Table.HeadCell>Avg completion</Table.HeadCell>
-                <Table.HeadCell>Avg progress</Table.HeadCell>
-              </Table.Head>
-              <Table.Body className="divide-y">
-                {sortedCourses.map((course) => (
-                  <Table.Row key={course.courseId}>
-                    <Table.Cell className="font-medium text-gray-900 dark:text-white">
-                      <Link href={`/courses/${course.courseId}/stats`} className="hover:underline">
-                        {course.name}
-                      </Link>
-                      {course.hidden && (
-                        <Badge color="gray" className="ml-2 inline-flex">
-                          Hidden
-                        </Badge>
-                      )}
-                    </Table.Cell>
-                    <Table.Cell>{course.level || "N/A"}</Table.Cell>
-                    <Table.Cell>{course.totalLearners}</Table.Cell>
-                    <Table.Cell>{course.enrolledCount}</Table.Cell>
-                    <Table.Cell>{course.completedCount}</Table.Cell>
-                    <Table.Cell>{course.droppedCount}</Table.Cell>
-                    <Table.Cell>{formatPercent(course.completionRate)}</Table.Cell>
-                    <Table.Cell>{formatDays(course.averageCompletionDays)}</Table.Cell>
-                    <Table.Cell>{formatPercent(course.averageProgressPercent)}</Table.Cell>
-                  </Table.Row>
-                ))}
-              </Table.Body>
-            </Table>
-          </div>
+          <SortableTable
+            columns={courseColumns}
+            data={courseStats}
+            rowKey={(c) => String(c.courseId)}
+            dataCy="course-stats-table"
+            defaultSort={{ key: "people", direction: "desc" }}
+          />
         </div>
       </div>
     </Layout>

--- a/pages/event/[eventId]/stats.tsx
+++ b/pages/event/[eventId]/stats.tsx
@@ -1,12 +1,13 @@
 import type { GetServerSideProps, NextPage } from "next"
 import Link from "next/link"
-import { Button, Table } from "flowbite-react"
+import { Button } from "flowbite-react"
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "pages/api/auth/[...nextauth]"
 import prisma from "lib/prisma"
 import Layout from "components/Layout"
 import Title from "components/ui/Title"
 import StatCard from "components/ui/StatCard"
+import SortableTable, { Column } from "components/ui/SortableTable"
 import { Material, getMaterial, removeMarkdown } from "lib/material"
 import { makeSerializable } from "lib/utils"
 import { loadPageTemplate, PageTemplate } from "lib/pageTemplate"
@@ -21,6 +22,22 @@ type EventStatsDetailPageProps = {
 }
 
 const EventStatsDetailPage: NextPage<EventStatsDetailPageProps> = ({ material, pageInfo, eventStats }) => {
+  const totalProblemsSolved = eventStats.learnerStats.reduce((sum, l) => sum + l.completedProblems, 0)
+  const totalProblemsAvailable = eventStats.learnerStats.reduce((sum, l) => sum + l.totalProblems, 0)
+
+  const sectionColumns: Column<(typeof eventStats.sectionStats)[number]>[] = [
+    { key: "title", label: "Section", sortable: true, getValue: (s) => s.title, render: (s) => s.url ? <Link href={s.url} className="hover:underline">{s.title}</Link> : s.title },
+    { key: "problems", label: "Problems", sortable: true, getValue: (s) => s.totalProblems, render: (s) => s.totalProblems },
+    { key: "avgCompletion", label: "Avg completion", sortable: true, getValue: (s) => s.averageCompletionPercent, render: (s) => formatPercent(s.averageCompletionPercent) },
+    { key: "fullyComplete", label: "Fully complete", sortable: true, getValue: (s) => s.fullyCompletedLearners, render: (s) => s.fullyCompletedLearners },
+  ]
+
+  const learnerColumns: Column<(typeof eventStats.learnerStats)[number]>[] = [
+    { key: "user", label: "User", sortable: true, getValue: (l) => l.userName || l.userEmail, cellClassName: "px-2 py-2", headCellClassName: "px-2 py-2", render: (l) => (<><div className="font-medium leading-tight text-gray-900 dark:text-white">{l.userName || l.userEmail}</div><div className="text-xs leading-tight text-gray-500 dark:text-gray-400">{l.userEmail}</div></>) },
+    { key: "status", label: "Status", sortable: true, getValue: (l) => l.status, cellClassName: "px-2 py-2 whitespace-nowrap", headCellClassName: "px-2 py-2", render: (l) => l.status },
+    { key: "progress", label: "Progress", sortable: true, getValue: (l) => l.completionPercent, cellClassName: "px-2 py-2 whitespace-nowrap", headCellClassName: "px-2 py-2", render: (l) => formatPercent(l.completionPercent) },
+    { key: "problems", label: "Problems", sortable: true, getValue: (l) => l.completedProblems, cellClassName: "px-2 py-2 whitespace-nowrap", headCellClassName: "px-2 py-2", render: (l) => l.totalProblems > 0 ? `${l.completedProblems}/${l.totalProblems}` : "N/A" },
+  ]
   const breadcrumbs: BreadcrumbItem[] = [
     { label: "Events", href: "/events" },
     { label: "Stats", href: "/events/stats" },
@@ -65,74 +82,35 @@ const EventStatsDetailPage: NextPage<EventStatsDetailPageProps> = ({ material, p
             value={eventStats.trackableProblems}
             dataCy="event-detail-stats-trackable-problems"
           />
+          <StatCard
+            label="Total problems solved"
+            value={`${totalProblemsSolved}/${totalProblemsAvailable}`}
+            dataCy="event-detail-stats-total-solved"
+          />
         </div>
 
         <div className="mt-8 grid grid-cols-1 gap-6 xl:grid-cols-2">
           <div>
             <Title text="Sections" className="text-2xl font-bold" style={{ marginBottom: "0px" }} />
-            <div className="mt-3 overflow-x-auto">
-              <Table data-cy="event-section-stats-table">
-                <Table.Head>
-                  <Table.HeadCell>Section</Table.HeadCell>
-                  <Table.HeadCell>Problems</Table.HeadCell>
-                  <Table.HeadCell>Avg completion</Table.HeadCell>
-                  <Table.HeadCell>Fully complete</Table.HeadCell>
-                </Table.Head>
-                <Table.Body className="divide-y">
-                  {eventStats.sectionStats.map((section) => (
-                    <Table.Row key={section.sectionRef}>
-                      <Table.Cell>
-                        {section.url ? (
-                          <Link href={section.url} className="hover:underline">
-                            {section.title}
-                          </Link>
-                        ) : (
-                          section.title
-                        )}
-                      </Table.Cell>
-                      <Table.Cell>{section.totalProblems}</Table.Cell>
-                      <Table.Cell>{formatPercent(section.averageCompletionPercent)}</Table.Cell>
-                      <Table.Cell>{section.fullyCompletedLearners}</Table.Cell>
-                    </Table.Row>
-                  ))}
-                </Table.Body>
-              </Table>
-            </div>
+            <SortableTable
+              columns={sectionColumns}
+              data={eventStats.sectionStats}
+              rowKey={(s) => s.sectionRef}
+              dataCy="event-section-stats-table"
+              wrapperClassName="mt-3 max-h-[600px] overflow-y-auto overflow-x-auto"
+            />
           </div>
 
           <div>
             <Title text="Users" className="text-2xl font-bold" style={{ marginBottom: "0px" }} />
-            <div className="mt-3 overflow-x-auto">
-              <Table data-cy="event-learner-stats-table" className="text-sm">
-                <Table.Head>
-                  <Table.HeadCell className="px-2 py-2">User</Table.HeadCell>
-                  <Table.HeadCell className="px-2 py-2">Status</Table.HeadCell>
-                  <Table.HeadCell className="px-2 py-2">Progress</Table.HeadCell>
-                  <Table.HeadCell className="px-2 py-2">Problems</Table.HeadCell>
-                </Table.Head>
-                <Table.Body className="divide-y">
-                  {eventStats.learnerStats.map((learner) => (
-                    <Table.Row key={`${learner.userEmail}-${learner.status}`}>
-                      <Table.Cell className="px-2 py-2">
-                        <div className="font-medium leading-tight text-gray-900 dark:text-white">
-                          {learner.userName || learner.userEmail}
-                        </div>
-                        <div className="text-xs leading-tight text-gray-500 dark:text-gray-400">
-                          {learner.userEmail}
-                        </div>
-                      </Table.Cell>
-                      <Table.Cell className="px-2 py-2 whitespace-nowrap">{learner.status}</Table.Cell>
-                      <Table.Cell className="px-2 py-2 whitespace-nowrap">
-                        {formatPercent(learner.completionPercent)}
-                      </Table.Cell>
-                      <Table.Cell className="px-2 py-2 whitespace-nowrap">
-                        {learner.totalProblems > 0 ? `${learner.completedProblems}/${learner.totalProblems}` : "N/A"}
-                      </Table.Cell>
-                    </Table.Row>
-                  ))}
-                </Table.Body>
-              </Table>
-            </div>
+            <SortableTable
+              columns={learnerColumns}
+              data={eventStats.learnerStats}
+              rowKey={(l) => `${l.userEmail}-${l.status}`}
+              dataCy="event-learner-stats-table"
+              tableClassName="text-sm"
+              defaultSort={{ key: "progress", direction: "desc" }}
+            />
           </div>
         </div>
       </div>

--- a/pages/events/stats.tsx
+++ b/pages/events/stats.tsx
@@ -1,12 +1,13 @@
 import type { GetServerSideProps, NextPage } from "next"
 import Link from "next/link"
-import { Badge, Button, Table } from "flowbite-react"
+import { Badge, Button } from "flowbite-react"
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "pages/api/auth/[...nextauth]"
 import prisma from "lib/prisma"
 import Layout from "components/Layout"
 import Title from "components/ui/Title"
 import StatCard from "components/ui/StatCard"
+import SortableTable, { Column } from "components/ui/SortableTable"
 import { Material, getMaterial, removeMarkdown } from "lib/material"
 import { makeSerializable } from "lib/utils"
 import { loadPageTemplate, PageTemplate } from "lib/pageTemplate"
@@ -30,7 +31,15 @@ type EventStatsPageProps = {
 const breadcrumbs: BreadcrumbItem[] = [{ label: "Events", href: "/events" }, { label: "Stats" }]
 
 const EventStatsPage: NextPage<EventStatsPageProps> = ({ material, pageInfo, overview, eventStats }) => {
-  const sortedEvents = [...eventStats].sort((a, b) => b.studentCount - a.studentCount || a.name.localeCompare(b.name))
+  const eventColumns: Column<EventStats>[] = [
+    { key: "name", label: "Event", sortable: true, getValue: (e) => e.name, render: (e) => (<><Link href={`/event/${e.eventId}/stats`} className="hover:underline font-medium text-gray-900 dark:text-white">{e.name}</Link>{e.hidden && <Badge color="gray" className="ml-2 inline-flex">Hidden</Badge>}</>) },
+    { key: "students", label: "Students", sortable: true, getValue: (e) => e.studentCount, render: (e) => e.studentCount },
+    { key: "instructors", label: "Instructors", sortable: true, getValue: (e) => e.instructorCount, render: (e) => e.instructorCount },
+    { key: "requests", label: "Requests", sortable: true, getValue: (e) => e.requestCount, render: (e) => e.requestCount },
+    { key: "groups", label: "Groups", sortable: true, getValue: (e) => e.groupCount, render: (e) => e.groupCount },
+    { key: "items", label: "Items", sortable: true, getValue: (e) => e.itemCount, render: (e) => e.itemCount },
+    { key: "avgProgress", label: "Avg progress", sortable: true, getValue: (e) => e.averageProgressPercent, render: (e) => formatPercent(e.averageProgressPercent) },
+  ]
 
   return (
     <Layout
@@ -80,41 +89,13 @@ const EventStatsPage: NextPage<EventStatsPageProps> = ({ material, pageInfo, ove
 
         <div className="mt-8">
           <Title text="By Event" className="text-2xl font-bold" style={{ marginBottom: "0px" }} />
-          <div className="mt-3 overflow-x-auto">
-            <Table data-cy="event-stats-table">
-              <Table.Head>
-                <Table.HeadCell>Event</Table.HeadCell>
-                <Table.HeadCell>Students</Table.HeadCell>
-                <Table.HeadCell>Instructors</Table.HeadCell>
-                <Table.HeadCell>Requests</Table.HeadCell>
-                <Table.HeadCell>Groups</Table.HeadCell>
-                <Table.HeadCell>Items</Table.HeadCell>
-                <Table.HeadCell>Avg progress</Table.HeadCell>
-              </Table.Head>
-              <Table.Body className="divide-y">
-                {sortedEvents.map((event) => (
-                  <Table.Row key={event.eventId}>
-                    <Table.Cell className="font-medium text-gray-900 dark:text-white">
-                      <Link href={`/event/${event.eventId}/stats`} className="hover:underline">
-                        {event.name}
-                      </Link>
-                      {event.hidden && (
-                        <Badge color="gray" className="ml-2 inline-flex">
-                          Hidden
-                        </Badge>
-                      )}
-                    </Table.Cell>
-                    <Table.Cell>{event.studentCount}</Table.Cell>
-                    <Table.Cell>{event.instructorCount}</Table.Cell>
-                    <Table.Cell>{event.requestCount}</Table.Cell>
-                    <Table.Cell>{event.groupCount}</Table.Cell>
-                    <Table.Cell>{event.itemCount}</Table.Cell>
-                    <Table.Cell>{formatPercent(event.averageProgressPercent)}</Table.Cell>
-                  </Table.Row>
-                ))}
-              </Table.Body>
-            </Table>
-          </div>
+          <SortableTable
+            columns={eventColumns}
+            data={eventStats}
+            rowKey={(e) => String(e.eventId)}
+            dataCy="event-stats-table"
+            defaultSort={{ key: "students", direction: "desc" }}
+          />
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
Closes #538

## Changes

1. **Sortable columns** — all stats tables now have clickable headers with 3-state sorting (desc → asc → reset). Sort indicators (⇅/▲/▼) are always visible so users know columns are interactive.

2. **Total problems solved** — new StatCard on event and course detail stats pages showing aggregate problems solved across all learners (e.g. "145/320").

3. **Sections table scroll fix** — sections tables on detail pages are now constrained to max 600px height with vertical scroll, preventing them from pushing all other content down.

## New component

`components/ui/SortableTable.tsx` — generic, typed, reusable sortable table built on Flowbite's Table component.

## How to test

1. Go to `/events/stats` or `/courses/stats` — click any column header to sort
2. Click same header again to reverse, third click resets to original order
3. Go to `/event/[id]/stats` — see "Total problems solved" StatCard and scrollable sections table
4. Same for `/courses/[id]/stats`