### PR TITLE
feat(events): per-event coordinator role (#530)

### DIFF
--- a/cypress/e2e/event-coordinator.cy.js
+++ b/cypress/e2e/event-coordinator.cy.js
@@ -1,0 +1,99 @@
+describe("event coordinator permissions", () => {
+  const admin = { name: "admin", email: "admin@localhost" }
+  const coordinator = { name: "notOnCourse", email: "notOnCourse@localhost" }
+  const other = { name: "instructorOnCourse", email: "instructorOnCourse@localhost" }
+  let eventId
+
+  const newEvent = (suffix) => ({
+    name: "Coordinator Event " + suffix,
+    summary: "summary",
+    enrol: "enrol",
+    content: "content",
+    enrolKey: "enrol_" + suffix,
+    instructorKey: "instr_" + suffix,
+    hidden: false,
+    start: "2026-04-01T09:00:00.000Z",
+    end: "2026-04-01T17:00:00.000Z",
+  })
+
+  beforeEach(() => {
+    const suffix = Date.now()
+    cy.login(admin)
+    cy.request("POST", "/api/event", newEvent(suffix)).then((res) => {
+      eventId = res.body.event.id
+      cy.login(coordinator)
+      cy.request("POST", `/api/userOnEvent/${eventId}`)
+      cy.login(admin)
+      cy.request("PUT", `/api/userOnEvent/${eventId}`, {
+        userOnEvent: { userEmail: coordinator.email, eventId, status: "COORDINATOR" },
+      })
+    })
+  })
+
+  afterEach(() => {
+    if (!eventId) return
+    cy.login(admin)
+    cy.request({ method: "DELETE", url: `/api/event/${eventId}`, failOnStatusCode: false })
+    eventId = undefined
+  })
+
+  it("lets a coordinator see the keys and edit their event", () => {
+    cy.login(coordinator)
+    cy.request("GET", `/api/event/${eventId}`).then((res) => {
+      expect(res.body.event.enrolKey).to.be.a("string")
+      cy.request("PUT", `/api/event/${eventId}`, {
+        event: { ...res.body.event, name: "Edited by coordinator", UserOnEvent: [], EventGroup: [] },
+      })
+        .its("status")
+        .should("eq", 200)
+    })
+    cy.login(admin)
+    cy.request("GET", `/api/event/${eventId}`).its("body.event.name").should("eq", "Edited by coordinator")
+  })
+
+  it("forbids a coordinator from deleting the event", () => {
+    cy.login(coordinator)
+    cy.request({ method: "DELETE", url: `/api/event/${eventId}`, failOnStatusCode: false })
+      .its("status")
+      .should("eq", 401)
+  })
+
+  it("forbids a logged-in non-coordinator from editing", () => {
+    cy.login(other)
+    cy.request({
+      method: "PUT",
+      url: `/api/event/${eventId}`,
+      failOnStatusCode: false,
+      body: { event: { name: "hacked", UserOnEvent: [], EventGroup: [] } },
+    })
+      .its("status")
+      .should("eq", 401)
+  })
+
+  it("only an admin can grant the COORDINATOR role", () => {
+    cy.login(other)
+    cy.request("POST", `/api/userOnEvent/${eventId}`)
+
+    cy.login(coordinator)
+    cy.request("GET", `/api/event/${eventId}`).then((res) => {
+      cy.request("PUT", `/api/event/${eventId}`, {
+        event: { ...res.body.event, EventGroup: [], UserOnEvent: [{ userEmail: other.email, status: "COORDINATOR" }] },
+      })
+    })
+    cy.login(admin)
+    cy.request("GET", `/api/event/${eventId}`).then((res) => {
+      const row = res.body.event.UserOnEvent.find((u) => u.userEmail === other.email)
+      expect(row.status).to.not.eq("COORDINATOR")
+    })
+
+    cy.request("GET", `/api/event/${eventId}`).then((res) => {
+      cy.request("PUT", `/api/event/${eventId}`, {
+        event: { ...res.body.event, EventGroup: [], UserOnEvent: [{ userEmail: other.email, status: "COORDINATOR" }] },
+      })
+    })
+    cy.request("GET", `/api/event/${eventId}`).then((res) => {
+      const row = res.body.event.UserOnEvent.find((u) => u.userEmail === other.email)
+      expect(row.status).to.eq("COORDINATOR")
+    })
+  })
+})

--- a/lib/eventAccess.ts
+++ b/lib/eventAccess.ts
@@ -1,0 +1,17 @@
+import prisma from "lib/prisma"
+
+export async function isEventCoordinator(userEmail: string | undefined, eventId: number): Promise<boolean> {
+  if (!userEmail || !Number.isInteger(eventId)) return false
+  const row = await prisma.userOnEvent.findFirst({
+    where: { userEmail, eventId, status: "COORDINATOR" },
+  })
+  return !!row
+}
+
+export async function isEventCoordinatorByGroup(userEmail: string | undefined, eventGroupId: number): Promise<boolean> {
+  if (!userEmail || !Number.isInteger(eventGroupId)) return false
+  const row = await prisma.userOnEvent.findFirst({
+    where: { userEmail, status: "COORDINATOR", event: { EventGroup: { some: { id: eventGroupId } } } },
+  })
+  return !!row
+}

--- a/pages/api/event/[eventId].ts
+++ b/pages/api/event/[eventId].ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 import prisma from "lib/prisma"
+import { isEventCoordinator } from "lib/eventAccess"
 
 import type { NextApiRequest, NextApiResponse } from "next"
 import { Prisma } from "@prisma/client"
@@ -35,6 +36,9 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse<Data>) => 
     return res.status(400).json({ error: "Invalid event id" })
   }
 
+  const isCoordinator = await isEventCoordinator(userEmail, eventId)
+  const canEdit = isAdmin || isCoordinator
+
   if (req.method === "GET") {
     const event = await prisma.event.findUnique({
       where: { id: eventId },
@@ -45,7 +49,7 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse<Data>) => 
     })
 
     if (!event) return res.status(404).json({ error: "Event not found" })
-    if (!isAdmin) {
+    if (!canEdit) {
       delete (event as any).enrolKey
       delete (event as any).instructorKey
     }
@@ -55,7 +59,7 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse<Data>) => 
     )
     const isStudent = event.UserOnEvent.some((u: UserOnEvent) => u.user?.email === userEmail && u.status === "STUDENT")
 
-    if (!isAdmin && !isInstructor && !isStudent) {
+    if (!canEdit && !isInstructor && !isStudent) {
       return res.status(401).json({ error: "Unauthorized" })
     }
 
@@ -67,7 +71,7 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse<Data>) => 
   }
 
   if (req.method === "PUT") {
-    if (!isAdmin) return res.status(401).json({ error: "Unauthorized" })
+    if (!canEdit) return res.status(401).json({ error: "Unauthorized" })
 
     const { name, enrol, content, enrolKey, instructorKey, start, end, summary, hidden } = req.body.event
     const eventGroupData: EventGroup[] = req.body.event.EventGroup ?? []
@@ -89,6 +93,8 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse<Data>) => 
 
     for (const user of req.body.event.UserOnEvent ?? []) {
       if (user.userEmail && user.status) {
+        // Only an admin may assign the COORDINATOR role.
+        if (user.status === "COORDINATOR" && !isAdmin) continue
         await prisma.userOnEvent.updateMany({
           where: {
             userEmail: user.userEmail,

--- a/pages/api/event/[eventId]/users.ts
+++ b/pages/api/event/[eventId]/users.ts
@@ -51,12 +51,17 @@ const EventUsers = async (req: NextApiRequest, res: NextApiResponse<Data>) => {
     (userOnEvent: UsersWithUserOnEvents) =>
       userOnEvent?.user?.name === user?.name && userOnEvent.status === "INSTRUCTOR"
   )
+  const isCoordinator = event?.UserOnEvent.some(
+    (userOnEvent: UsersWithUserOnEvents) =>
+      userOnEvent?.user?.email === userEmail && userOnEvent.status === "COORDINATOR"
+  )
   const isAdmin = currentUser?.admin === true
+  const canManage = isInstructor || isCoordinator || isAdmin
 
   let users: UsersWithUserOnEvents[] = []
   switch (method) {
     case "GET":
-      if (isInstructor || isAdmin) {
+      if (canManage) {
         const onEvent = event?.UserOnEvent
         const emails = onEvent.map((userOnEvent: UsersWithUserOnEvents) => userOnEvent?.userEmail || "")
         users = await prisma.userOnEvent.findMany({
@@ -68,7 +73,7 @@ const EventUsers = async (req: NextApiRequest, res: NextApiResponse<Data>) => {
       res.status(200).json({ users })
       break
     case "PUT":
-      if (!isInstructor && !isAdmin) {
+      if (!canManage) {
         return res.status(403).json({ error: "Forbidden" })
       }
       users = req.body.users
@@ -79,9 +84,14 @@ const EventUsers = async (req: NextApiRequest, res: NextApiResponse<Data>) => {
         const userEmail = userOnEvent.userEmail as string
         const existingUserOnEvent = await prisma.userOnEvent.findUnique({
           where: { userEmail_eventId: { userEmail, eventId } },
+          include: { user: true },
         })
         if (!existingUserOnEvent) {
           return "UserOnEvent not found"
+        }
+        // Only an admin may assign the COORDINATOR role.
+        if (userOnEvent.status === "COORDINATOR" && !isAdmin) {
+          return existingUserOnEvent
         }
         // only update status
         const updatedUserOnEvent = await prisma.userOnEvent.update({

--- a/pages/api/eventGroup/[eventGroupId].ts
+++ b/pages/api/eventGroup/[eventGroupId].ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 import prisma from "lib/prisma"
+import { isEventCoordinatorByGroup } from "lib/eventAccess"
 
 import type { NextApiRequest, NextApiResponse } from "next"
 import { Prisma } from "@prisma/client"
@@ -33,6 +34,8 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse<Data>) => 
 
   const eventGroupId = req.query.eventGroupId as string
 
+  const canEdit = isAdmin || (await isEventCoordinatorByGroup(userEmail, parseInt(eventGroupId)))
+
   if (req.method === "GET") {
     const isInstructorStudent = await prisma.userOnEvent.findFirst({
       where: {
@@ -42,7 +45,7 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse<Data>) => 
       },
     })
 
-    const hasAccess = isAdmin || isInstructorStudent
+    const hasAccess = canEdit || isInstructorStudent
 
     const eventGroup = await prisma.eventGroup.findUnique({
       where: { id: parseInt(eventGroupId) },
@@ -64,7 +67,7 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse<Data>) => 
     const { name, content, start, end, summary, location } = req.body.eventGroup
     const eventItemData: EventItem[] = req.body.eventGroup.EventItem
 
-    if (!isAdmin) {
+    if (!canEdit) {
       res.status(401).json({ error: "Unauthorized" })
       return
     }
@@ -98,7 +101,7 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse<Data>) => 
     }
     res.status(200).json({ eventGroup: updatedEventGroup })
   } else if (req.method === "DELETE") {
-    if (!isAdmin) {
+    if (!canEdit) {
       res.status(401).json({ error: "Unauthorized" })
       return
     }

--- a/pages/event/[eventId].tsx
+++ b/pages/event/[eventId].tsx
@@ -86,6 +86,8 @@ const Event: NextPage<EventProps> = ({ material, event, pageInfo }) => {
   )
   const isInstructor = myUserOnEvent?.status === "INSTRUCTOR"
   const isAdmin = !!userProfile?.admin
+  const isCoordinator = myUserOnEvent?.status === "COORDINATOR"
+  const canEdit = isAdmin || isCoordinator
   const sectionsOptions = useMemo(() => buildSectionsOptions(material), [material])
 
   const onSubmit = async (data: EventForm) => {
@@ -156,6 +158,7 @@ const Event: NextPage<EventProps> = ({ material, event, pageInfo }) => {
   const statusOptions = [
     { label: "student", value: "STUDENT" },
     { label: "instructor", value: "INSTRUCTOR" },
+    ...(isAdmin ? [{ label: "coordinator", value: "COORDINATOR" }] : []),
     { label: "request", value: "REQUEST" },
     { label: "reject", value: "REJECTED" },
   ]
@@ -166,7 +169,7 @@ const Event: NextPage<EventProps> = ({ material, event, pageInfo }) => {
       eventWithRelations={eventData}
       material={material}
       isAdmin={isAdmin}
-      isInstructor={!!isInstructor}
+      isInstructor={!!isInstructor || isCoordinator}
     />
   )
 
@@ -245,7 +248,7 @@ const Event: NextPage<EventProps> = ({ material, event, pageInfo }) => {
           </Link>
         </div>
       )}
-      {eventData && isAdmin ? (
+      {eventData && canEdit ? (
         <Tabs.Group style="underline" ref={tabsRef} onActiveTabChange={handleTabChange}>
           <Tabs.Item active={activeTabIndex === 0} icon={MdPreview} title="Event">
             {eventView}

--- a/prisma/migrations/20260529142019_add_coordinator_event_status/migration.sql
+++ b/prisma/migrations/20260529142019_add_coordinator_event_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "EventStatus" ADD VALUE 'COORDINATOR';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,7 @@ enum EventStatus {
   REQUEST
   STUDENT
   INSTRUCTOR
+  COORDINATOR
   REJECTED
 }
 


### PR DESCRIPTION
## Summary
Implements #530: a per-event `coordinator` role so an admin can let someone edit a single event without granting global admin rights.

## Changes
- `EventStatus.COORDINATOR` enum value + migration
- `lib/eventAccess.ts` helper (`admin || coordinator`)
- Authorize coordinators on event edit (`PUT /api/event/[id]`), event group edit/delete, and event user management
- Admin-only kept for: deleting an event, creating events, and granting the COORDINATOR role
- UI: edit tab shown to coordinators; `coordinator` option in the user role selector visible to admins only

## Testing
- New `cypress/e2e/event-coordinator.cy.js` (4 cases) — passing locally against a test DB
- `tsc --noEmit` clean, Prettier clean
- Manual UI check: admin assigns coordinator; coordinator can edit but cannot delete the event or promote others

Closes #530